### PR TITLE
Simplify InMobiMediatedNativeAppInstallAd init

### DIFF
--- a/adapters/InMobi/InMobiAdapter/InMobiMediatedNativeAppInstallAd.m
+++ b/adapters/InMobi/InMobiAdapter/InMobiMediatedNativeAppInstallAd.m
@@ -10,8 +10,9 @@
 #import "InMobiMediatedNativeAppInstallAd.h"
 #import "NativeAdKeys.h"
 
-@interface InMobiMediatedNativeAppInstallAd () <GADMediatedNativeAdDelegate,
-                                                InMobiMediatedNativeAppInstallAdDelegate>
+static CGFloat const DefaultIconScale = 1.0;
+
+@interface InMobiMediatedNativeAppInstallAd () <GADMediatedNativeAdDelegate, InMobiMediatedNativeAppInstallAdDelegate>
 
 @property(nonatomic, strong) IMNative *native;
 @property(nonatomic, strong) GADNativeAdImage *mappedIcon;
@@ -23,100 +24,140 @@
 
 @implementation InMobiMediatedNativeAppInstallAd
 
-//@synthesize adDelegate;
 @synthesize adapter = adapter_;
-//@synthesize connector = _connector;
 
 - (instancetype)initWithInMobiNativeAppInstallAd:(IMNative *)nativeAd
                                      withAdapter:(GADMAdapterInMobi *)adapter
                              shouldDownloadImage:(BOOL)shouldDownloadImage
                                        withCache:(NSCache *)imageCache {
-  if (!nativeAd) {
-    return nil;
-  }
-  self = [super init];
-  self.adapter = adapter;
-  self.native = nativeAd;
-  NSData *data = [self.native.customAdContent dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *error = nil;
-  SEL inmobiMediatedNativeAppInstallAdSuccessful =
-      @selector(inmobiMediatedNativeAppInstallAdSuccessful:);
+    if (!nativeAd) {
+        return nil;
+    }
+    self = [super init];
+    self.adapter = adapter;
+    self.native = nativeAd;
 
-  if (data) {
-    self.nativeAdContentDictionary =
-        [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];
+    NSData *data = [self.native.customAdContent dataUsingEncoding:NSUTF8StringEncoding];
+    __weak InMobiMediatedNativeAppInstallAd *weakSelf = self;
+    [self setupWithData:data shouldDownloadImage:shouldDownloadImage imageCache:imageCache completed:^{
+        [weakSelf notifyCompletion];
+    }];
+    return self;
+}
+
+#pragma mark - Setup Data
+
+- (void)setupWithData:(NSData *)data shouldDownloadImage:(BOOL)shouldDownloadImage imageCache:(NSCache *)imageCache completed:(void(^)())completed {
+    if (!data) {
+        completed();
+        return;
+    }
+
+    self.nativeAdContentDictionary = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
     NSDictionary *iconDictionary = [self.nativeAdContentDictionary objectForKey:ICON];
 
-    if (iconDictionary) {
-      NSString *iconStringURL = [iconDictionary objectForKey:URL];
-      if (![[self.native adTitle] length] || ![[self.native adDescription] length] ||
-          ![[self.native adCtaText] length] || ![self.native adIcon] || ![iconStringURL length]) {
-        [self inmobiMediatedNativeAppInstallAdFailed];
-        return nil;
-      } else {
-        self.extras = [[NSDictionary alloc]
-            initWithObjectsAndKeys:[self.nativeAdContentDictionary objectForKey:LANDING_URL],
-                                   LANDING_URL, nil];
+    if (!iconDictionary) {
+        completed();
+        return;
+    }
+
+    NSString *iconStringURL = [iconDictionary objectForKey:URL];
+    if ([self isValidWithNativeAd:self.native imageURL:iconStringURL]) {
+        self.extras = [[NSDictionary alloc] initWithObjectsAndKeys:[self.nativeAdContentDictionary objectForKey:LANDING_URL], LANDING_URL, nil];
         NSURL *iconURL = [NSURL URLWithString:iconStringURL];
-        CGFloat iconScale = 1.0;
 
         // Pass a blank image since we are using only mediaview.
-        UIImage *img;
         UIGraphicsBeginImageContextWithOptions(CGSizeMake(36, 36), NO, 0.0);
-        img = UIGraphicsGetImageFromCurrentImageContext();
+        UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
 
-        self.mappedImages = @[ [[GADNativeAdImage alloc] initWithImage:img] ];
+        self.mappedImages = @[[[GADNativeAdImage alloc] initWithImage:img]];
 
         if (!shouldDownloadImage) {
-          self.mappedIcon = [[GADNativeAdImage alloc] initWithURL:iconURL scale:iconScale];
-          if ([self respondsToSelector:inmobiMediatedNativeAppInstallAdSuccessful]) {
-            [self inmobiMediatedNativeAppInstallAdSuccessful:self];
-          }
+            self.mappedIcon = [[GADNativeAdImage alloc] initWithURL:iconURL scale:DefaultIconScale];
+            completed();
         } else {
-          dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-            UIImage *icon;
-            [iconStringURL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-            UIImage *cacheIcon = [imageCache objectForKey:iconStringURL];
-            if (cacheIcon) {
-              icon = cacheIcon;
-            } else {
-              NSData *iconData = [NSData dataWithContentsOfURL:[NSURL URLWithString:iconStringURL]];
-              icon = [UIImage imageWithData:iconData];
-              [imageCache setObject:icon forKey:iconStringURL];
-            }
-
-            self.mappedIcon = [[GADNativeAdImage alloc] initWithImage:icon];
-
-            if (icon && img) {
-              [self inmobiMediatedNativeAppInstallAdSuccessful:self];
-            } else {
-              [self inmobiMediatedNativeAppInstallAdFailed];
-            }
-          });
+            NSURL *imageURL = [NSURL URLWithString:iconStringURL];
+            __weak InMobiMediatedNativeAppInstallAd *weakSelf = self;
+            [self loadImageWithURL:imageURL imageCache:imageCache callback:^(UIImage *image) {
+                weakSelf.mappedIcon = [[GADNativeAdImage alloc] initWithImage:image];
+                completed();
+            }];
         }
-      }
     } else {
-      [self inmobiMediatedNativeAppInstallAdFailed];
+        completed();
     }
-  }
-  return self;
+}
+
+#pragma mark - Async Image
+
+- (void)loadImageWithURL:(NSURL *)url imageCache:(NSCache *)imageCache callback:(void(^)(UIImage *))callback {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSString *cacheKey = [url.absoluteString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        UIImage *cachedImage = [imageCache objectForKey:cacheKey];
+        if (!cachedImage) {
+            NSData *imageData = [NSData dataWithContentsOfURL:url];
+            UIImage *image = [UIImage imageWithData:imageData];
+            if (image) {
+                [imageCache setObject:cachedImage forKey:cacheKey];
+                cachedImage = image;
+            }
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            callback(cachedImage);
+        });
+    });
+}
+
+#pragma mark - Completion
+
+- (void)notifyCompletion {
+    if (self.mappedIcon && self.mappedImages) {
+        [self notifyMediatedNativeAppInstallAdSuccessful];
+    } else {
+        [self notifyMediatedNativeAppInstallAdFailed];
+    }
+}
+
+- (void)notifyMediatedNativeAppInstallAdSuccessful {
+    if ([self respondsToSelector:@selector(inmobiMediatedNativeAppInstallAdSuccessful:)]) {
+        [self inmobiMediatedNativeAppInstallAdSuccessful:self];
+    }
+}
+
+- (void)notifyMediatedNativeAppInstallAdFailed {
+    if ([self respondsToSelector:@selector(inmobiMediatedNativeAppInstallAdFailed)]) {
+        [self inmobiMediatedNativeAppInstallAdFailed];
+    }
+}
+
+#pragma mark - Helpers
+
+- (BOOL)isValidWithNativeAd:(IMNative *)native imageURL:(NSString *)imageURL {
+    if (![[native adTitle] length] ||
+        ![[native adDescription] length] ||
+        ![[native adCtaText] length] ||
+        ![native adIcon] ||
+        ![imageURL length]) {
+        return NO;
+    }
+    return YES;
 }
 
 - (NSString *)headline {
-  return self.native.adTitle;
+    return self.native.adTitle;
 }
 
 - (NSString *)body {
-  return self.native.adDescription;
+    return self.native.adDescription;
 }
 
 - (GADNativeAdImage *)icon {
-  return self.mappedIcon;
+    return self.mappedIcon;
 }
 
 - (NSString *)callToAction {
-  return self.native.adCtaText;
+    return self.native.adCtaText;
 }
 
 - (NSDecimalNumber *)starRating {
@@ -127,22 +168,22 @@
 }
 
 - (NSString *)store {
-  NSString *landingURL = (NSString *)(self.native.adLandingPageUrl.absoluteString);
-  if (landingURL) {
-    NSRange searchedRange = NSMakeRange(0, [landingURL length]);
-    NSError *error = nil;
-    NSRegularExpression *regex =
+    NSString *landingURL = (NSString *)(self.native.adLandingPageUrl.absoluteString);
+    if (landingURL) {
+        NSRange searchedRange = NSMakeRange(0, [landingURL length]);
+        NSError *error = nil;
+        NSRegularExpression *regex =
         [NSRegularExpression regularExpressionWithPattern:@"\\S*:\\/\\/itunes\\.apple\\.com\\S*"
                                                   options:0
                                                     error:&error];
-    NSUInteger numberOfMatches =
+        NSUInteger numberOfMatches =
         [regex numberOfMatchesInString:landingURL options:0 range:searchedRange];
-    if (numberOfMatches == 0)
-      return @"Others";
-    else
-      return @"iTunes";
-  }
-  return @"";
+        if (numberOfMatches == 0)
+            return @"Others";
+        else
+            return @"iTunes";
+    }
+    return @"";
 }
 
 - (NSString *)price {
@@ -153,60 +194,60 @@
 }
 
 - (NSArray *)images {
-  return self.mappedImages;
+    return self.mappedImages;
 }
 
 - (NSDictionary *)extraAssets {
-  return self.extras;
+    return self.extras;
 }
 
 - (UIView *GAD_NULLABLE_TYPE)mediaView {
-  UIView *placeHolderView = [[UIView alloc] initWithFrame:CGRectZero];
-  placeHolderView.userInteractionEnabled = NO;
-  return placeHolderView;
+    UIView *placeHolderView = [[UIView alloc] initWithFrame:CGRectZero];
+    placeHolderView.userInteractionEnabled = NO;
+    return placeHolderView;
 }
 
 - (BOOL)hasVideoContent {
-  return true;
+    return true;
 }
 
 - (id<GADMediatedNativeAdDelegate>)mediatedNativeAdDelegate {
-  return self;
+    return self;
 }
 
 - (void)mediatedNativeAd:(id<GADMediatedNativeAd>)mediatedNativeAd
-    didRecordClickOnAssetWithName:(NSString *)assetName
-                             view:(UIView *)view
-                   viewController:(UIViewController *)viewController {
-  if (self.native) {
-    [self.native reportAdClickAndOpenLandingPage];
-  }
+didRecordClickOnAssetWithName:(NSString *)assetName
+                    view:(UIView *)view
+          viewController:(UIViewController *)viewController {
+    if (self.native) {
+        [self.native reportAdClickAndOpenLandingPage];
+    }
 }
 
 - (void)mediatedNativeAd:(id<GADMediatedNativeAd>)mediatedNativeAd
          didRenderInView:(UIView *)view
           viewController:(UIViewController *)viewController {
-  GADNativeAppInstallAdView *adView = (GADNativeAppInstallAdView *)view;
-  GADMediaView *mediaView = adView.mediaView;
-  UIView *primaryView = [self.native primaryViewOfWidth:mediaView.frame.size.width];
-  [mediaView addSubview:primaryView];
+    GADNativeAppInstallAdView *adView = (GADNativeAppInstallAdView *)view;
+    GADMediaView *mediaView = adView.mediaView;
+    UIView *primaryView = [self.native primaryViewOfWidth:mediaView.frame.size.width];
+    [mediaView addSubview:primaryView];
 }
 
 - (void)mediatedNativeAd:(id<GADMediatedNativeAd>)mediatedNativeAd didUntrackView:(UIView *)view {
-  [self.native recyclePrimaryView];
-  self.native = nil;
+    [self.native recyclePrimaryView];
+    self.native = nil;
 }
 
 - (void)inmobiMediatedNativeAppInstallAdFailed {
-  GADRequestError *reqError =
-      [GADRequestError errorWithDomain:kGADErrorDomain code:kGADErrorMediationNoFill userInfo:nil];
-  [self.adapter.connector adapter:self.adapter didFailAd:reqError];
+    GADRequestError *reqError =
+    [GADRequestError errorWithDomain:kGADErrorDomain code:kGADErrorMediationNoFill userInfo:nil];
+    [self.adapter.connector adapter:self.adapter didFailAd:reqError];
 }
 
 - (void)inmobiMediatedNativeAppInstallAdSuccessful:(InMobiMediatedNativeAppInstallAd *)ad {
-  if (self.adapter != nil && self.adapter.connector != nil) {
-    [self.adapter.connector adapter:self.adapter didReceiveMediatedNativeAd:ad];
-  }
+    if (self.adapter != nil && self.adapter.connector != nil) {
+        [self.adapter.connector adapter:self.adapter didReceiveMediatedNativeAd:ad];
+    }
 }
 
 @end


### PR DESCRIPTION
Updated `InMobiMediatedNativeAppInstallAd` initialization method.

### Tasks
- Simplified `init` method by extracting into few methods.
- Added additional check to prevent this crash: https://github.com/googleads/googleads-mobile-ios-mediation/issues/50
- Ensured that callback is in the main thread.
- Fallback to default Xcode code formation