### PR TITLE
Set mediation service for Facebook adapter

### DIFF
--- a/adapters/Facebook/FacebookAdapter/GADFBBannerAd.m
+++ b/adapters/Facebook/FacebookAdapter/GADFBBannerAd.m
@@ -14,6 +14,7 @@
 
 #import "GADFBBannerAd.h"
 
+@import GoogleMobileAds;
 @import FBAudienceNetwork;
 
 #import "GADFBAdapterDelegate.h"
@@ -130,6 +131,7 @@ static FBAdSize GADFBAdSizeFromAdSize(GADAdSize gadAdSize, NSError *__autoreleas
   if (size.size.width < 0) {
     _adapterDelegate.finalBannerSize = adSize.size;
   }
+  [FBAdSettings setMediationService:[NSString stringWithFormat:@"ADMOB_%@", [GADRequest sdkVersion]];
   [_bannerAd loadAd];
 }
 

--- a/adapters/Facebook/FacebookAdapter/GADFBInterstitialAd.m
+++ b/adapters/Facebook/FacebookAdapter/GADFBInterstitialAd.m
@@ -79,6 +79,7 @@
   }
 
   _interstitialAd.delegate = _adapterDelegate;
+  [FBAdSettings setMediationService:[NSString stringWithFormat:@"ADMOB_%@", [GADRequest sdkVersion]];
   [_interstitialAd loadAd];
 }
 

--- a/adapters/Facebook/FacebookAdapter/GADFBNativeAd.m
+++ b/adapters/Facebook/FacebookAdapter/GADFBNativeAd.m
@@ -141,6 +141,7 @@ static NSString *const GADNativeAdIcon = @"2";
   _mediaView = [[FBMediaView alloc] initWithNativeAd:_nativeAd];
   _mediaView.delegate = self;
   _nativeAd.delegate = self;
+  [FBAdSettings setMediationService:[NSString stringWithFormat:@"ADMOB_%@", [GADRequest sdkVersion]];
   [_nativeAd loadAd];
 }
 

--- a/adapters/Facebook/FacebookAdapter/GADFBRewardedVideoAd.m
+++ b/adapters/Facebook/FacebookAdapter/GADFBRewardedVideoAd.m
@@ -89,6 +89,7 @@
     return;
   }
   _rewardedVideoAd.delegate = _adapterDelegate;
+  [FBAdSettings setMediationService:[NSString stringWithFormat:@"ADMOB_%@", [GADRequest sdkVersion]];
   [_rewardedVideoAd loadAd];
 }
 


### PR DESCRIPTION
Update FAN Adapter to include AdMob SDK Version as mediation service flag for reporting. It is using FBAdSettings from Audience Network SDK.