### PR TITLE
Separate keywords passing + Initialize MoPub

### DIFF
--- a/adapters/MoPub/MoPubAdapter/GADMAdapterMoPub.m
+++ b/adapters/MoPub/MoPubAdapter/GADMAdapterMoPub.m
@@ -22,7 +22,6 @@ static NSString *const kAdapterErrorDomain = @"com.mopub.mobileads.MoPubAdapter"
 
 /// Internal to MoPub
 static NSString *const kAdapterTpValue = @"gmext";
-BOOL isMoPubInitialized = NO;
 
 @interface GADMAdapterMoPub () <MPNativeAdDelegate, MPAdViewDelegate,
                                 MPInterstitialAdControllerDelegate>
@@ -51,12 +50,11 @@ BOOL isMoPubInitialized = NO;
 }
 
 - (void) initializeMoPub:(NSString *) adUnitId {
-    if (!isMoPubInitialized) {
+    if (![[MoPub sharedInstance] isSdkInitialized]) {
         MPMoPubConfiguration * sdkConfig = [[MPMoPubConfiguration alloc] initWithAdUnitIdForAppInitialization: adUnitId];
 
         [[MoPub sharedInstance] initializeSdkWithConfiguration:sdkConfig completion:^{
             NSLog(@"MoPub SDK initialized.");
-            isMoPubInitialized = YES;
         }];
     }
 }

--- a/adapters/MoPub/MoPubAdapter/MoPubAdapterMediatedNativeAd.m
+++ b/adapters/MoPub/MoPubAdapter/MoPubAdapterMediatedNativeAd.m
@@ -106,7 +106,7 @@
 
 - (void)privacyIconTapped {
   _displayDestinationAgent =
-      [[MPCoreInstanceProvider sharedProvider] buildMPAdDestinationDisplayAgentWithDelegate:self];
+      [MPAdDestinationDisplayAgent agentWithDelegate:self];
   [_displayDestinationAgent
       displayDestinationForURL:[NSURL URLWithString:kDAAIconTapDestinationURL]];
 }


### PR DESCRIPTION
* As of MoPub 5.0.0, keywords needed to be separate into two APIs based on whether they contain personally identifiable information.
* Initialize the MoPub SDK in the adapter with a valid ad unit ID from the publisher's app.