### PR TITLE
Use #import instead of @import

### DIFF
--- a/adapters/AdColony/Public/Headers/GADMAdapterAdColonyExtras.h
+++ b/adapters/AdColony/Public/Headers/GADMAdapterAdColonyExtras.h
@@ -2,7 +2,7 @@
 // Copyright 2016, AdColony, Inc.
 //
 
-@import GoogleMobileAds;
+#import <GoogleMobileAds/GoogleMobileAds.h>
 
 @interface GADMAdapterAdColonyExtras : NSObject<GADAdNetworkExtras>
 


### PR DESCRIPTION
This is a Unity specific nit. 

If you're building an iOS Unity project with this adapter included, the default behavior is to building without support for '@import' ('Enable Modules' setting in Build Settings). So the default build won't compile until you make the change I'm proposing, or enable modules in settings. Not a huge deal, but unless there's a reason to use '@import' instead of '#import', this cleans up the experience of using this adapter in Unity!