### PR TITLE
Updating Facebook Adapter to version 5.2.0.0

### DIFF
--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Facebook Audience Network Mediation Adapter for Google Mobile Ads SDK for iOS
 
+## Version 5.2.0.0
+- Replaced FBAdChoicesView with FBAdOptionsView.
+
 ## Version 5.1.1.0
 - Verified compatibility with FAN SDK 5.1.1.
 

--- a/adapters/Facebook/FacebookAdapter/GADFBNativeAd.m
+++ b/adapters/Facebook/FacebookAdapter/GADFBNativeAd.m
@@ -51,8 +51,8 @@ static NSString *const GADUnifiedNativeAdIconView = @"3003";
   /// Serializes ivar usage.
   dispatch_queue_t _lockQueue;
 
-  /// Facebook AdChoices view.
-  FBAdChoicesView *_adChoicesView;
+  /// Facebook AdOptions view.
+  FBAdOptionsView *_adOptionsView;
 
   /// YES if an impression has been logged.
   BOOL _impressionLogged;
@@ -136,19 +136,30 @@ static NSString *const GADUnifiedNativeAdIconView = @"3003";
 }
 
 - (void)loadAdChoicesView {
-  id<GADMAdNetworkConnector> strongConnector = _connector;
-  id obj = [strongConnector networkExtras];
-  GADFBNetworkExtras *networkExtras = [obj isKindOfClass:[GADFBNetworkExtras class]] ? obj : nil;
-  if (!_adChoicesView) {
-    if (networkExtras) {
-      _adChoicesView = [[FBAdChoicesView alloc] initWithNativeAd:self->_nativeAd
-                                                      expandable:networkExtras.adChoicesExpandable];
-      _adChoicesView.backgroundShown = networkExtras.adChoicesBackgroundShown;
-    } else {
-      _adChoicesView = [[FBAdChoicesView alloc] initWithNativeAd:self->_nativeAd];
-    }
+  if (!_adOptionsView) {
+      _adOptionsView = [[FBAdOptionsView alloc] init];
+      _adOptionsView.backgroundColor = [UIColor clearColor];
+      
+      NSLayoutConstraint *height = [NSLayoutConstraint
+                                    constraintWithItem:_adOptionsView
+                                    attribute:NSLayoutAttributeHeight
+                                    relatedBy:NSLayoutRelationEqual
+                                    toItem:nil
+                                    attribute:NSLayoutAttributeNotAnAttribute
+                                    multiplier:0
+                                    constant:FBAdOptionsViewHeight];
+      NSLayoutConstraint *width = [NSLayoutConstraint
+                                   constraintWithItem:_adOptionsView
+                                   attribute:NSLayoutAttributeWidth
+                                   relatedBy:NSLayoutRelationEqual
+                                   toItem:nil
+                                   attribute:NSLayoutAttributeNotAnAttribute
+                                   multiplier:0
+                                   constant:FBAdOptionsViewWidth];
+      [_adOptionsView addConstraint:height];
+      [_adOptionsView addConstraint:width];
+      [_adOptionsView updateConstraints];
   }
-  [_adChoicesView updateFrameFromSuperview];
 }
 
 #pragma mark - GADMediatedNativeAd
@@ -235,7 +246,7 @@ static NSString *const GADUnifiedNativeAdIconView = @"3003";
 }
 
 - (UIView *GAD_NULLABLE_TYPE)adChoicesView {
-  return _adChoicesView;
+  return _adOptionsView;
 }
 
 /// Returns YES if the ad has video content.
@@ -273,10 +284,11 @@ static NSString *const GADUnifiedNativeAdIconView = @"3003";
                             iconImageView:iconView
                            viewController:viewController];
   }
+  _adOptionsView.nativeAd = _nativeAd;
 }
 
 - (void)mediatedNativeAd:(id<GADMediatedNativeAd>)mediatedNativeAd didUntrackView:(UIView *)view {
-  [_adChoicesView removeFromSuperview];
+  [_adOptionsView removeFromSuperview];
   [_nativeAd unregisterView];
 }
 

--- a/adapters/Facebook/FacebookAdapter/GADMAdapterFacebook.m
+++ b/adapters/Facebook/FacebookAdapter/GADMAdapterFacebook.m
@@ -45,7 +45,7 @@
 @implementation GADMAdapterFacebook
 
 + (NSString *)adapterVersion {
-  return @"5.1.1.0";
+  return @"5.2.0.0";
 }
 
 + (Class<GADAdNetworkExtras>)networkExtrasClass {


### PR DESCRIPTION
Preparing adapter for Facebook Audience Network 5.2.0. This adapter works with the Beta SDK which can be downloaded from https://developers.facebook.com/docs/audience-network/sdk-beta-program.

This PR includes: 
* Replacing FBAdChoicesView with FBAdOptionsView.
* Bumping up adapter version.

<img width="382" alt="screen shot 2019-02-11 at 1 29 30 pm" src="https://user-images.githubusercontent.com/2929173/52595471-d29fa180-2e02-11e9-9637-51acc3af0a44.png">
