### PR TITLE
Update Facebook adapter to version 5.3.2.0

### DIFF
--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Facebook Audience Network Mediation Adapter for Google Mobile Ads SDK for iOS
 
 ## Version 5.3.2.0
-- Removed dependency on CoreLocation.framework
+- Verified compatibility with FAN SDK 5.3.2.
 
 ## Version 5.3.0.0
 - Changed the mediation service string include adapter version.

--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Facebook Audience Network Mediation Adapter for Google Mobile Ads SDK for iOS
 
+## Version 5.3.2.0
+- Removed dependency on CoreLocation.framework
+
 ## Version 5.3.0.0
 - Changed the mediation service string include adapter version.
 - Fixed a bug for native ads where AdOptions wasn't initialized correctly.

--- a/adapters/Facebook/FacebookAdapter/GADMAdapterFacebookConstants.h
+++ b/adapters/Facebook/FacebookAdapter/GADMAdapterFacebookConstants.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Facebook mediation network adapter version.
-static NSString *const kGADMAdapterFacebookVersion = @"5.3.0.0";
+static NSString *const kGADMAdapterFacebookVersion = @"5.3.2.0";
 
 static NSString *const kGADMAdapterFacebookOpenBiddingPubID = @"placement_id";
 

--- a/adapters/Facebook/FacebookAdapter/GADMediationAdapterFacebook.m
+++ b/adapters/Facebook/FacebookAdapter/GADMediationAdapterFacebook.m
@@ -49,7 +49,7 @@
   }
   FBAdInitSettings *fbSettings = [[FBAdInitSettings alloc]
       initWithPlacementIDs:[placementIds allObjects]
-                 mediationService:[NSString stringWithFormat:@"GOOGLE_%@", [GADRequest sdkVersion]]];
+          mediationService:[NSString stringWithFormat:@"GOOGLE_%@:%@", [GADRequest sdkVersion], kGADMAdapterFacebookVersion]];
 
   [FBAudienceNetworkAds
       initializeWithSettings:fbSettings


### PR DESCRIPTION
This version removes a dependency on CoreLocation.framework and fixes minor bugs.
https://developers.facebook.com/docs/audience-network/changelog-ios#5_3_2