### PR TITLE
Fix an issue where `onReady:` doesn't properly trigger callback to Admob

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnitySingleton.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnitySingleton.m
@@ -257,12 +257,14 @@
 
 - (void)unityAdsReady:(NSString *)placementID {
   id<GADMAdapterUnityDataProvider, UnityAdsExtendedDelegate> adapterDelegate;
-  @synchronized(_adapterDelegates) {
-    GADMAdapterUnityMapTableRemoveObjectForKey(_adapterDelegates, placementID);
-  }
+  adapterDelegate = [_adapterDelegates objectForKey:placementID];
 
   if (adapterDelegate) {
     [adapterDelegate unityAdsReady:placementID];
+  }
+
+  @synchronized(_adapterDelegates) {
+    GADMAdapterUnityMapTableRemoveObjectForKey(_adapterDelegates, placementID);
   }
 
   if (_isBannerLoading && [placementID isEqualToString:_bannerPlacementID]) {


### PR DESCRIPTION
**Issue**
The `unityAdsReady:` method in `GADMAdapterUnitySingleton` does not set the callback delegate properly, so the first load request does not inform the Admob SDK that it's ready

**Change**
Set the delegate, then send the callback before removing the delegate from the delegate map