### PR TITLE
Updating Fyber Adapter to version 7.5.1

### DIFF
--- a/adapters/Fyber/CHANGELOG.md
+++ b/adapters/Fyber/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Fyber iOS Mediation Adapter Changelog
 
+#### Version 7.5.1.0
+- Verified compatibility with Fyber Marketplace SDK version 7.5.1.
+- Fixed bug in the SDK init.
+
+Built and tested with:
+- Google Mobile Ads SDK version 7.53.1.
+- Fyber Marketplace SDK version 7.5.1.
+
+
 #### Version 7.5.0.0
 - Verified compatibility with Fyber Marketplace SDK version 7.5.0.
 - Adapter will now initialize the Fyber SDK before making an ad request if the Fyber SDK has not been initialized yet.

--- a/adapters/Fyber/FyberAdapter/GADMAdapterFyberConstants.h
+++ b/adapters/Fyber/FyberAdapter/GADMAdapterFyberConstants.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Fyber mediation adapter version.
-static NSString* const _Nonnull kGADMAdapterFyberVersion = @"7.5.0.0";
+static NSString* const _Nonnull kGADMAdapterFyberVersion = @"7.5.1.0";
 
 /// Fyber mediation adapter app ID key.
 static NSString* const _Nonnull kGADMAdapterFyberApplicationID = @"applicationId";

--- a/adapters/Fyber/FyberAdapter/GADMAdapterFyberUtils.m
+++ b/adapters/Fyber/FyberAdapter/GADMAdapterFyberUtils.m
@@ -106,8 +106,6 @@ BOOL GADMAdapterFyberInitializeWithAppID(NSString *_Nonnull appID,
 
   [IALogger setLogLevel:IALogLevelInfo];
   GADMAdapterFyberLog(@"Configuring Fyber Marketplace SDK with application ID: %@.", appID);
-  dispatch_sync(dispatch_get_main_queue(), ^{
-    [IASDKCore.sharedInstance initWithAppID:appID];
-  });
+  [IASDKCore.sharedInstance initWithAppID:appID];
   return (IASDKCore.sharedInstance.appID != nil);
 }


### PR DESCRIPTION
Update the adapter to version 7.5.1
Fixed bug: calling `dispatch_sync(dispatch_get_main_queue()` caused crash. There is no need to do it on the main thread since the init flow will continue with another thread anyway.