### PR TITLE
updating TapjoyAdapter to version 12.4.2.0

### DIFF
--- a/adapters/Tapjoy/TapjoyAdapter/GADMAdapterTapjoyConstants.h
+++ b/adapters/Tapjoy/TapjoyAdapter/GADMAdapterTapjoyConstants.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Tapjoy mediation network adapter version.
-static NSString *const _Nonnull kGADMAdapterTapjoyVersion = @"12.4.1.0";
+static NSString *const _Nonnull kGADMAdapterTapjoyVersion = @"12.4.2.0";
 
 /// Tapjoy mediation network adapter mediation agent.
 static NSString *const _Nonnull kGADMAdapterTapjoyMediationAgent = @"admob";


### PR DESCRIPTION
This PR is to update Tapjoy Adapter version to 12.4.2 