### PR TITLE
Correct mapping of tagForChildDirectedTreatment to setMixedAudience in Facebook adapter

### DIFF
--- a/adapters/Facebook/CHANGELOG.md
+++ b/adapters/Facebook/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Facebook iOS Mediation Adapter Changelog
 
+#### Next Version
+- Fix bug introduced in 5.6.1.0 where `tagForChildDirectedTreatment` was incorrectly mapped to Facebook's
+  `setMixedAudience` method.
+
 #### Version 5.8.0.0
 - Verified compatibility with FAN SDK 5.8.0.
 - Adapter now returns a non-zero `mediaContent` aspect ratio regardless if the media view is rendered or not.

--- a/adapters/Facebook/FacebookAdapter/GADFBUtils.m
+++ b/adapters/Facebook/FacebookAdapter/GADFBUtils.m
@@ -42,5 +42,5 @@ void GADMAdapterFacebookMutableSetAddObject(NSMutableSet *_Nullable set,
 }
 
 void GADMAdapterFacebookSetMixedAudience(NSNumber *_Nonnull childDirectedTreatment) {
-  [FBAdSettings setMixedAudience:!childDirectedTreatment.boolValue];
+  [FBAdSettings setMixedAudience:childDirectedTreatment.boolValue];
 }


### PR DESCRIPTION
Correct mapping of tagForChildDirectedTreatment to setMixedAudience in Facebook adapter
