### PR TITLE
Vungle AdMob Adapter 6.7.1.0

### DIFF
--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Vungle iOS Mediation Adapter Changelog
 
-#### Next Version
+#### Version 6.7.1.0
+- Verified compatibility with Vungle SDK 6.7.1.
 - Fixed an issue where `didFailToPresentWithError:` was not called when a rewarded ad failed to present.
+
+Build and tested with
+- Google Mobile Ads SDK version 7.62.0.
+- Vungle SDK version 6.7.1.
 
 #### Version 6.7.0.0
 - Verified compatibility with Vungle SDK 6.7.0.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.7.0.0";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.7.1.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";


### PR DESCRIPTION
Vungle AdMob Adapter 6.7.1.0 is compatible with Vungle SDK 6.7.1.