### PR TITLE
Chartboost 8.3.0.0

### DIFF
--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 
 /// Chartboost mediation network adapter version.
-static NSString *const kGADMAdapterChartboostVersion = @"8.2.1.0";
+static NSString *const kGADMAdapterChartboostVersion = @"8.3.0.0";
 
 /// Chartboost App ID.
 static NSString *const kGADMAdapterChartboostAppID = @"appId";


### PR DESCRIPTION
Chartboost SDK 8.3.0 will be soon released as I'm writing this.
I'm creating this PR now for reference, as you can see there's no code changes. Just a changelog update would be needed.