### PR TITLE
Release 6.8.0.0 Vungle AdMob Adapter 

### DIFF
--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 #### Version 6.8.0.0
 - Verified compatibility with Vungle SDK 6.8.0.
+- Now requires Google Mobile Ads SDK version 7.65.0 or higher.
 
 Build and tested with
-- Google Mobile Ads SDK version 7.64.0.
+- Google Mobile Ads SDK version 7.65.0.
 - Vungle SDK version 6.8.0.
 
 #### Version 6.7.1.0

--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Vungle iOS Mediation Adapter Changelog
 
+#### Version 6.8.0.0
+- Verified compatibility with Vungle SDK 6.8.0.
+
+Build and tested with
+- Google Mobile Ads SDK version 7.64.0.
+- Vungle SDK version 6.8.0.
+
 #### Version 6.7.1.0
 - Verified compatibility with Vungle SDK 6.7.1.
 - Now requires Google Mobile Ads SDK version 7.64.0 or higher.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.7.1.0";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.8.0.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";


### PR DESCRIPTION
This version of the adapters has been certified with Vungle 6.8.0.