### PR TITLE
Updating myTarget iOS Adapter to version 5.9.2.0

### DIFF
--- a/adapters/MyTarget/CHANGELOG.md
+++ b/adapters/MyTarget/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Verified compatibility with myTarget SDK version 5.9.2.
 
 Build and tested With:
-- Google Mobile Ads SDK version 7.66.0.
+- Google Mobile Ads SDK version 7.67.0.
 - MyTarget SDK version 5.9.2
 
 #### Version 5.7.5.0

--- a/adapters/MyTarget/CHANGELOG.md
+++ b/adapters/MyTarget/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## myTarget iOS Mediation Adapter Changelog
 
+#### Version 5.9.2.0
+- Verified compatibility with myTarget SDK version 5.9.2.
+
+Build and tested With:
+- Google Mobile Ads SDK version 7.66.0.
+- MyTarget SDK version 5.9.2
+
 #### Version 5.7.5.0
 - Verified compatibility with myTarget SDK version 5.7.5.
 

--- a/adapters/MyTarget/MyTargetAdapter/GADMAdapterMyTarget.m
+++ b/adapters/MyTarget/MyTargetAdapter/GADMAdapterMyTarget.m
@@ -26,10 +26,13 @@
 /// Find closest supported ad size from a given ad size.
 /// Returns nil if no supported size matches.
 static GADAdSize GADSupportedAdSizeFromRequestedSize(GADAdSize gadAdSize) {
+  MTRGAdSize *adSizeAdaptive = [MTRGAdSize adSizeForCurrentOrientationForWidth:gadAdSize.size.width];
+  GADAdSize gadAdSizeAdaptive = GADAdSizeFromCGSize(adSizeAdaptive.size);
   NSArray<NSValue *> *potentials = @[
     NSValueFromGADAdSize(kGADAdSizeBanner),
     NSValueFromGADAdSize(kGADAdSizeMediumRectangle),
     NSValueFromGADAdSize(kGADAdSizeLeaderboard),
+    NSValueFromGADAdSize(gadAdSizeAdaptive)
   ];
   return GADClosestValidSizeForAdSizes(gadAdSize, potentials);
 }
@@ -71,7 +74,7 @@ static GADAdSize GADSupportedAdSizeFromRequestedSize(GADAdSize gadAdSize) {
 }
 
 - (void)getBannerWithSize:(GADAdSize)adSize {
-  MTRGLogInfo();
+  MTRGLogDebug(@"getBannerWithSize: %@", NSStringFromGADAdSize(adSize));
 
   id<GADMAdNetworkConnector> strongConnector = _connector;
   if (!strongConnector) {
@@ -86,9 +89,9 @@ static GADAdSize GADSupportedAdSizeFromRequestedSize(GADAdSize gadAdSize) {
     adViewSize = [MTRGAdSize adSize300x250];
   } else if (GADAdSizeEqualToSize(adSize, kGADAdSizeLeaderboard)) {
     adViewSize = [MTRGAdSize adSize728x90];
-  } else if (adSize.size.width < 0 && adSize.size.height < 0) {
+  } else if (!GADAdSizeEqualToSize(adSize, kGADAdSizeInvalid)) {
 	// Adaptive
-    adViewSize = [MTRGAdSize adSizeForCurrentOrientation];
+    adViewSize = [MTRGAdSize adSizeForCurrentOrientationForWidth:adSize.size.width];
   } else {
     MTRGLogError(kGADMAdapterMyTargetErrorInvalidSize);
     [strongConnector adapter:self

--- a/adapters/MyTarget/MyTargetAdapter/GADMAdapterMyTargetConstants.h
+++ b/adapters/MyTarget/MyTargetAdapter/GADMAdapterMyTargetConstants.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// myTarget mediation network adapter version.
-static NSString *const _Nonnull kGADMAdapterMyTargetVersion = @"5.7.5.0";
+static NSString *const _Nonnull kGADMAdapterMyTargetVersion = @"5.9.2.0";
 
 /// myTarget mediation network adapter slot ID server parameter key.
 static NSString *const _Nonnull kGADMAdapterMyTargetSlotIdKey = @"slotId";

--- a/adapters/MyTarget/MyTargetAdapter/GADMAdapterMyTargetRewardedAd.m
+++ b/adapters/MyTarget/MyTargetAdapter/GADMAdapterMyTargetRewardedAd.m
@@ -22,7 +22,7 @@
 #import "GADMAdapterMyTargetExtras.h"
 #import "GADMAdapterMyTargetUtils.h"
 
-@interface GADMAdapterMyTargetRewardedAd () <MTRGInterstitialAdDelegate>
+@interface GADMAdapterMyTargetRewardedAd () <MTRGRewardedAdDelegate>
 @end
 
 @implementation GADMAdapterMyTargetRewardedAd {
@@ -38,7 +38,7 @@
   id<GADMediationRewardedAdEventDelegate> _adEventDelegate;
 
   /// myTarget rewarded ad object.
-  MTRGInterstitialAd *_rewardedAd;
+  MTRGRewardedAd *_rewardedAd;
 }
 
 BOOL _isRewardedAdLoaded;
@@ -93,7 +93,7 @@ BOOL _isRewardedAdLoaded;
   }
 
   _isRewardedAdLoaded = NO;
-  _rewardedAd = [[MTRGInterstitialAd alloc] initWithSlotId:slotId];
+  _rewardedAd = [MTRGRewardedAd rewardedAdWithSlotId:slotId];
   _rewardedAd.delegate = self;
   // INFO: This is where you can pass customParams if you want to send any.
   [_rewardedAd load];
@@ -110,33 +110,34 @@ BOOL _isRewardedAdLoaded;
   [_rewardedAd showWithController:viewController];
 }
 
-#pragma mark - MTRGInterstitialAdDelegate
+#pragma mark - MTRGRewardedAdDelegate
 
-- (void)onLoadWithInterstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onLoadWithRewardedAd:(MTRGRewardedAd *)rewardedAd {
   MTRGLogInfo();
   _isRewardedAdLoaded = YES;
   _adEventDelegate = _completionHandler(self, nil);
 }
 
-- (void)onNoAdWithReason:(nonnull NSString *)reason
-          interstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onNoAdWithReason:(NSString *)reason
+              rewardedAd:(MTRGRewardedAd *)rewardedAd {
   MTRGLogInfo();
   MTRGLogError(reason);
   NSError *error = GADMAdapterMyTargetSDKErrorWithDescription(reason);
   _completionHandler(nil, error);
 }
 
-- (void)onClickWithInterstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onClickWithRewardedAd:(MTRGRewardedAd *)rewardedAd {
   MTRGLogInfo();
   [_adEventDelegate reportClick];
 }
 
-- (void)onCloseWithInterstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onCloseWithRewardedAd:(MTRGRewardedAd *)rewardedAd {
   MTRGLogInfo();
   [_adEventDelegate didDismissFullScreenView];
 }
 
-- (void)onVideoCompleteWithInterstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onReward:(MTRGReward *)reward
+      rewardedAd:(MTRGRewardedAd *)rewardedAd {
   MTRGLogInfo();
   [_adEventDelegate didEndVideo];
 
@@ -147,13 +148,13 @@ BOOL _isRewardedAdLoaded;
   [_adEventDelegate didRewardUserWithReward:adReward];
 }
 
-- (void)onDisplayWithInterstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onDisplayWithRewardedAd:(MTRGRewardedAd *)rewardedAd {
   MTRGLogInfo();
   [_adEventDelegate willPresentFullScreenView];
   [_adEventDelegate didStartVideo];
 }
 
-- (void)onLeaveApplicationWithInterstitialAd:(nonnull MTRGInterstitialAd *)interstitialAd {
+- (void)onLeaveApplicationWithRewardedAd:(MTRGRewardedAd *)rewardedAd {
   // Do nothing. The Google Mobile Ads SDK does not have an equivalent callback.
 }
 


### PR DESCRIPTION
Supported GoogleMobileAds 7.66.0 and myTarget 5.9.2
