### PR TITLE
Add completion handler null check to prevent crash

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
@@ -176,14 +176,18 @@
 
 - (void)initializationComplete {
   NSLog(@"Unity Ads initialized successfully");
-  _initCompletionHandler(nil);
+  if (_initCompletionHandler) {
+    _initCompletionHandler(nil);
+  }
 }
 
 - (void)initializationFailed:(UnityAdsInitializationError)error
                  withMessage:(nonnull NSString *)message {
-  NSError *adapterError = GADMAdapterUnityErrorWithCodeAndDescription(
-      GADMAdapterUnityErrorAdInitializationFailure, message);
-  _initCompletionHandler(adapterError);
+  if (_initCompletionHandler) {
+    NSError *adapterError = GADMAdapterUnityErrorWithCodeAndDescription(
+        GADMAdapterUnityErrorAdInitializationFailure, message);
+    _initCompletionHandler(adapterError);
+  }
 }
 
 @end


### PR DESCRIPTION
### Description
This pr is to add back the if check for completion handler which we previously added in the [pr](https://github.com/googleads/googleads-mobile-ios-mediation/pull/270/files#diff-3049d5d2e2115b254321aef39709c848cccde2e9956eef921f4776817cc68cefR195). 
As this completion handler could be null in many cases, without the check it causes app crash for many users.