### PR TITLE
Enable background downloading by default in Vungle Adapter

### DIFF
--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -99,6 +99,9 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   // Disable refresh functionality for all banners
   [[VungleSDK sharedSDK] disableBannerRefresh];
 
+  // Enable background downloading
+  [VungleSDK enableBackgroundDownload:YES];
+
   // Set init options for priority placement
   NSMutableDictionary *initOptions = [NSMutableDictionary dictionary];
   if (delegate) {


### PR DESCRIPTION
This PR is enabling background downloading by default in 6.9.1.0 Vungle Adapter.