### PR TITLE
Fix MoPub ad mis-alignment when using AdMob Adaptive Banners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Xcode
+.DS_Store
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/
+
+# Repository exclusions
+Drop_Framework_And_Headers/
+Library/

--- a/adapters/MoPub/MoPubAdapter/GADMAdapterMoPub.m
+++ b/adapters/MoPub/MoPubAdapter/GADMAdapterMoPub.m
@@ -262,6 +262,10 @@ static NSMapTable<NSString *, GADMAdapterMoPub *> *GADMAdapterMoPubInterstitialD
       return;
     }
   }
+  
+  // Update view bounds with the actual size of the ad returned
+  CGRect loadedAdBounds = CGRectMake(view.bounds.origin.x, view.bounds.origin.y, adSize.width, adSize.height);
+  view.bounds = loadedAdBounds;
 
   [strongConnector adapter:self didReceiveAdView:view];
 }


### PR DESCRIPTION
### Issue Description
- MoPub SDK requires to set the frame of MPAdView **before** loading any ad.
- With Adaptive Banners the frame is set to _requestedAdSize, which is dynamic and can be larger than 320x50.
- When an Ad is finally loaded, MPAdView frame never gets updated with the actual size of the ad returned.
- This causes the content of the ad to be top-left aligned inside the larger frame set initially.

### Solution
- Make sure that MPAdView frame is adjusted to the correct size of the ad loaded, this in return assures that the ad is displayed centred in the frame available for Adaptive Banners.