### PR TITLE
Chartboost SDK 8.4.2

### DIFF
--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 
 /// Chartboost mediation network adapter version.
-static NSString *const kGADMAdapterChartboostVersion = @"8.4.1.1";
+static NSString *const kGADMAdapterChartboostVersion = @"8.4.2.0";
 
 /// Chartboost App ID.
 static NSString *const kGADMAdapterChartboostAppID = @"appId";


### PR DESCRIPTION
Updated Chartboost adapter version string.
Just a reminder to get an adapters update released with support for the latest Chartboost SDK.