### PR TITLE
Release 6.10.1.0 Vungle AdMob Adapter

### DIFF
--- a/adapters/Vungle/CHANGELOG.md
+++ b/adapters/Vungle/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Vungle iOS Mediation Adapter Changelog
 
+#### Version 6.10.1.0
+- Verified compatibility with Vungle SDK 6.10.1.
+
 #### Version 6.10.0.0  (rolled back)
 - Verified compatibility with Vungle SDK 6.10.0.
 - Relaxed dependency to Google Mobile Ads SDK version 8.0.0 or higher.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.9.2.0";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.1.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";


### PR DESCRIPTION
This version of the adapter has been certified with Vungle 6.10.1 SDK.