### PR TITLE
Nend Adapter: call adapterDidGetAdClick: when interstitial ads clicked.

### DIFF
--- a/adapters/Nend/NendAdapter/GADMAdapterNend.m
+++ b/adapters/Nend/NendAdapter/GADMAdapterNend.m
@@ -251,6 +251,7 @@ static GADAdSize GADSupportedAdSizeFromRequestedSize(GADAdSize gadAdSize) {
   id<GADMAdNetworkConnector> strongConnector = _connector;
   switch (type) {
     case DOWNLOAD:
+      [strongConnector adapterDidGetAdClick:self];
     case INFORMATION:
       [strongConnector adapterWillDismissInterstitial:self];
       [strongConnector adapterDidDismissInterstitial:self];
@@ -311,6 +312,7 @@ static GADAdSize GADSupportedAdSizeFromRequestedSize(GADAdSize gadAdSize) {
       [_connector adapterWillLeaveApplication:self];
       break;
   }
+  [_connector adapterDidGetAdClick:self];
 }
 
 - (void)nadInterstitialVideoAdDidClickInformation:


### PR DESCRIPTION
Fixes: Not called adDidRecordClick: delegate method when interstitial ads clicked by Google Mobile Ads SDK v8.7.0 or higher.