### PR TITLE
Vungle Bidding

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdapter.h
+++ b/adapters/Vungle/Public/Headers/VungleAdapter.h
@@ -15,5 +15,5 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import <VungleAdapter/VungleAdNetworkExtras.h>
-#import <VungleAdapter/VungleRouterConsent.h>
+#import "VungleAdNetworkExtras.h"
+#import "VungleRouterConsent.h"

--- a/adapters/Vungle/VungleAdapter.xcodeproj/project.pbxproj
+++ b/adapters/Vungle/VungleAdapter.xcodeproj/project.pbxproj
@@ -33,8 +33,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00802E53248848850077C6D0 /* GADMAdapterVungleBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 00802E51248848850077C6D0 /* GADMAdapterVungleBanner.h */; };
-		00802E54248848850077C6D0 /* GADMAdapterVungleBanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 00802E52248848850077C6D0 /* GADMAdapterVungleBanner.m */; };
+		176AE0D62613E49000E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.h in Headers */ = {isa = PBXBuildFile; fileRef = 176AE0D52613E49000E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.h */; };
+		176AE0DB2613E49C00E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.m in Sources */ = {isa = PBXBuildFile; fileRef = 176AE0DA2613E49C00E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.m */; };
+		176EA85A26E021EF00B492E0 /* GADMAdapterVungleBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 176EA85826E021EF00B492E0 /* GADMAdapterVungleBanner.h */; };
+		176EA85B26E021EF00B492E0 /* GADMAdapterVungleBanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 176EA85926E021EF00B492E0 /* GADMAdapterVungleBanner.m */; };
+		178ADB1A2612A082007587F0 /* GADMediationVungleInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = 178ADB142612A081007587F0 /* GADMediationVungleInterstitial.m */; };
+		178ADB1D2612A082007587F0 /* GADMediationVungleBanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 178ADB172612A082007587F0 /* GADMediationVungleBanner.m */; };
+		178ADB1E2612A082007587F0 /* GADMediationVungleBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 178ADB182612A082007587F0 /* GADMediationVungleBanner.h */; };
+		178ADB1F2612A082007587F0 /* GADMediationVungleInterstitial.h in Headers */ = {isa = PBXBuildFile; fileRef = 178ADB192612A082007587F0 /* GADMediationVungleInterstitial.h */; };
 		407621A123F140B800C18557 /* VungleRouterConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4076219F23F140B800C18557 /* VungleRouterConfiguration.m */; };
 		407621A223F140B800C18557 /* VungleRouterConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 407621A023F140B800C18557 /* VungleRouterConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4552392A20B6381E0081388F /* VungleRouterConsent.m in Sources */ = {isa = PBXBuildFile; fileRef = 4552392720B6381D0081388F /* VungleRouterConsent.m */; };
@@ -47,14 +53,12 @@
 		4593F490227CE28A00F57AE5 /* GADMAdapterVungleUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4593F48E227CE28A00F57AE5 /* GADMAdapterVungleUtils.m */; };
 		45BFFB5922272D1000C96A67 /* GADMediationAdapterVungle.h in Headers */ = {isa = PBXBuildFile; fileRef = 45BFFB5722272D1000C96A67 /* GADMediationAdapterVungle.h */; };
 		45BFFB5A22272D1000C96A67 /* GADMediationAdapterVungle.m in Sources */ = {isa = PBXBuildFile; fileRef = 45BFFB5822272D1000C96A67 /* GADMediationAdapterVungle.m */; };
-		45BFFB5D22272D4300C96A67 /* GADMAdapterVungleRewardedAd.h in Headers */ = {isa = PBXBuildFile; fileRef = 45BFFB5B22272D4300C96A67 /* GADMAdapterVungleRewardedAd.h */; };
-		45BFFB5E22272D4300C96A67 /* GADMAdapterVungleRewardedAd.m in Sources */ = {isa = PBXBuildFile; fileRef = 45BFFB5C22272D4300C96A67 /* GADMAdapterVungleRewardedAd.m */; };
+		45BFFB5D22272D4300C96A67 /* GADMediationVungleRewardedAd.h in Headers */ = {isa = PBXBuildFile; fileRef = 45BFFB5B22272D4300C96A67 /* GADMediationVungleRewardedAd.h */; };
+		45BFFB5E22272D4300C96A67 /* GADMediationVungleRewardedAd.m in Sources */ = {isa = PBXBuildFile; fileRef = 45BFFB5C22272D4300C96A67 /* GADMediationVungleRewardedAd.m */; };
 		56C4F0F21F29531200BABF7E /* VungleAdNetworkExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 56C4F0F11F29531200BABF7E /* VungleAdNetworkExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D1575721EB7FBB200059469 /* VungleAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D1575711EB7FBB200059469 /* VungleAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A85428E01F11853A00C135E7 /* GADMAdapterVungleInterstitial.h in Headers */ = {isa = PBXBuildFile; fileRef = A85428D81F11853A00C135E7 /* GADMAdapterVungleInterstitial.h */; };
 		A85428E11F11853A00C135E7 /* GADMAdapterVungleInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = A85428D91F11853A00C135E7 /* GADMAdapterVungleInterstitial.m */; };
-		A85428E21F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.h in Headers */ = {isa = PBXBuildFile; fileRef = A85428DA1F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.h */; };
-		A85428E31F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.m in Sources */ = {isa = PBXBuildFile; fileRef = A85428DB1F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.m */; };
 		A85428E51F11853A00C135E7 /* VungleAdNetworkExtras.m in Sources */ = {isa = PBXBuildFile; fileRef = A85428DD1F11853A00C135E7 /* VungleAdNetworkExtras.m */; };
 /* End PBXBuildFile section */
 
@@ -88,9 +92,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00802E51248848850077C6D0 /* GADMAdapterVungleBanner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleBanner.h; sourceTree = "<group>"; };
-		00802E52248848850077C6D0 /* GADMAdapterVungleBanner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleBanner.m; sourceTree = "<group>"; };
 		00DD26AB22F10DD20039C1D4 /* Script_Validate.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Script_Validate.sh; sourceTree = "<group>"; };
+		176AE0D52613E49000E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleRewardBasedVideoAd.h; sourceTree = "<group>"; };
+		176AE0DA2613E49C00E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleRewardBasedVideoAd.m; sourceTree = "<group>"; };
+		176EA85826E021EF00B492E0 /* GADMAdapterVungleBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleBanner.h; sourceTree = "<group>"; };
+		176EA85926E021EF00B492E0 /* GADMAdapterVungleBanner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleBanner.m; sourceTree = "<group>"; };
+		178ADB142612A081007587F0 /* GADMediationVungleInterstitial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADMediationVungleInterstitial.m; sourceTree = "<group>"; };
+		178ADB172612A082007587F0 /* GADMediationVungleBanner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADMediationVungleBanner.m; sourceTree = "<group>"; };
+		178ADB182612A082007587F0 /* GADMediationVungleBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADMediationVungleBanner.h; sourceTree = "<group>"; };
+		178ADB192612A082007587F0 /* GADMediationVungleInterstitial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADMediationVungleInterstitial.h; sourceTree = "<group>"; };
 		4076219F23F140B800C18557 /* VungleRouterConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VungleRouterConfiguration.m; sourceTree = "<group>"; };
 		407621A023F140B800C18557 /* VungleRouterConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VungleRouterConfiguration.h; sourceTree = "<group>"; };
 		4552392720B6381D0081388F /* VungleRouterConsent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VungleRouterConsent.m; sourceTree = "<group>"; };
@@ -103,8 +113,8 @@
 		4593F48E227CE28A00F57AE5 /* GADMAdapterVungleUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleUtils.m; sourceTree = "<group>"; };
 		45BFFB5722272D1000C96A67 /* GADMediationAdapterVungle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMediationAdapterVungle.h; sourceTree = "<group>"; };
 		45BFFB5822272D1000C96A67 /* GADMediationAdapterVungle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMediationAdapterVungle.m; sourceTree = "<group>"; };
-		45BFFB5B22272D4300C96A67 /* GADMAdapterVungleRewardedAd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleRewardedAd.h; sourceTree = "<group>"; };
-		45BFFB5C22272D4300C96A67 /* GADMAdapterVungleRewardedAd.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleRewardedAd.m; sourceTree = "<group>"; };
+		45BFFB5B22272D4300C96A67 /* GADMediationVungleRewardedAd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMediationVungleRewardedAd.h; sourceTree = "<group>"; };
+		45BFFB5C22272D4300C96A67 /* GADMediationVungleRewardedAd.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMediationVungleRewardedAd.m; sourceTree = "<group>"; };
 		56C4F0F11F29531200BABF7E /* VungleAdNetworkExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VungleAdNetworkExtras.h; sourceTree = "<group>"; };
 		7D1575711EB7FBB200059469 /* VungleAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VungleAdapter.h; sourceTree = "<group>"; };
 		7D264FF01DDD1B4E00027720 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -118,8 +128,6 @@
 		7DFABB1D1DA8682C00322E02 /* libAdapter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAdapter.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A85428D81F11853A00C135E7 /* GADMAdapterVungleInterstitial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleInterstitial.h; sourceTree = "<group>"; };
 		A85428D91F11853A00C135E7 /* GADMAdapterVungleInterstitial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleInterstitial.m; sourceTree = "<group>"; };
-		A85428DA1F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADMAdapterVungleRewardBasedVideoAd.h; sourceTree = "<group>"; };
-		A85428DB1F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterVungleRewardBasedVideoAd.m; sourceTree = "<group>"; };
 		A85428DD1F11853A00C135E7 /* VungleAdNetworkExtras.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VungleAdNetworkExtras.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -134,20 +142,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		178ADB0626129548007587F0 /* Bidding */ = {
+			isa = PBXGroup;
+			children = (
+				178ADB182612A082007587F0 /* GADMediationVungleBanner.h */,
+				178ADB172612A082007587F0 /* GADMediationVungleBanner.m */,
+				178ADB192612A082007587F0 /* GADMediationVungleInterstitial.h */,
+				178ADB142612A081007587F0 /* GADMediationVungleInterstitial.m */,
+				45BFFB5B22272D4300C96A67 /* GADMediationVungleRewardedAd.h */,
+				45BFFB5C22272D4300C96A67 /* GADMediationVungleRewardedAd.m */,
+			);
+			path = Bidding;
+			sourceTree = "<group>";
+		};
 		7D15756E1EB7FB9200059469 /* VungleAdapter */ = {
 			isa = PBXGroup;
 			children = (
+				178ADB0626129548007587F0 /* Bidding */,
+				176EA85826E021EF00B492E0 /* GADMAdapterVungleBanner.h */,
+				176EA85926E021EF00B492E0 /* GADMAdapterVungleBanner.m */,
 				4076219F23F140B800C18557 /* VungleRouterConfiguration.m */,
-				00802E51248848850077C6D0 /* GADMAdapterVungleBanner.h */,
-				00802E52248848850077C6D0 /* GADMAdapterVungleBanner.m */,
 				4593F48B227CDC9300F57AE5 /* GADMAdapterVungleConstants.h */,
 				4557855A238DE7E700523142 /* GADMAdapterVungleDelegate.h */,
 				A85428D81F11853A00C135E7 /* GADMAdapterVungleInterstitial.h */,
 				A85428D91F11853A00C135E7 /* GADMAdapterVungleInterstitial.m */,
-				A85428DA1F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.h */,
-				A85428DB1F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.m */,
-				45BFFB5B22272D4300C96A67 /* GADMAdapterVungleRewardedAd.h */,
-				45BFFB5C22272D4300C96A67 /* GADMAdapterVungleRewardedAd.m */,
 				458F734D2385DFF2006738A0 /* GADMAdapterVungleRouter.h */,
 				458F734E2385DFF2006738A0 /* GADMAdapterVungleRouter.m */,
 				4593F48D227CE28A00F57AE5 /* GADMAdapterVungleUtils.h */,
@@ -156,6 +174,8 @@
 				45BFFB5822272D1000C96A67 /* GADMediationAdapterVungle.m */,
 				A85428DD1F11853A00C135E7 /* VungleAdNetworkExtras.m */,
 				4552392720B6381D0081388F /* VungleRouterConsent.m */,
+				176AE0D52613E49000E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.h */,
+				176AE0DA2613E49C00E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.m */,
 			);
 			path = VungleAdapter;
 			sourceTree = "<group>";
@@ -229,16 +249,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				4593F48F227CE28A00F57AE5 /* GADMAdapterVungleUtils.h in Headers */,
-				00802E53248848850077C6D0 /* GADMAdapterVungleBanner.h in Headers */,
+				178ADB1F2612A082007587F0 /* GADMediationVungleInterstitial.h in Headers */,
+				176AE0D62613E49000E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.h in Headers */,
 				407621A223F140B800C18557 /* VungleRouterConfiguration.h in Headers */,
 				A85428E01F11853A00C135E7 /* GADMAdapterVungleInterstitial.h in Headers */,
-				45BFFB5D22272D4300C96A67 /* GADMAdapterVungleRewardedAd.h in Headers */,
+				45BFFB5D22272D4300C96A67 /* GADMediationVungleRewardedAd.h in Headers */,
 				4557855B238DE7E700523142 /* GADMAdapterVungleDelegate.h in Headers */,
 				458F734F2385DFF2006738A0 /* GADMAdapterVungleRouter.h in Headers */,
 				7D1575721EB7FBB200059469 /* VungleAdapter.h in Headers */,
+				178ADB1E2612A082007587F0 /* GADMediationVungleBanner.h in Headers */,
 				56C4F0F21F29531200BABF7E /* VungleAdNetworkExtras.h in Headers */,
-				A85428E21F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.h in Headers */,
 				45BFFB5922272D1000C96A67 /* GADMediationAdapterVungle.h in Headers */,
+				176EA85A26E021EF00B492E0 /* GADMAdapterVungleBanner.h in Headers */,
 				4593F48C227CDC9300F57AE5 /* GADMAdapterVungleConstants.h in Headers */,
 				4552392C20B638270081388F /* VungleRouterConsent.h in Headers */,
 			);
@@ -339,14 +361,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00802E54248848850077C6D0 /* GADMAdapterVungleBanner.m in Sources */,
+				178ADB1D2612A082007587F0 /* GADMediationVungleBanner.m in Sources */,
+				A85428E11F11853A00C135E7 /* GADMAdapterVungleInterstitial.m in Sources */,
+				178ADB1A2612A082007587F0 /* GADMediationVungleInterstitial.m in Sources */,
+				45BFFB5E22272D4300C96A67 /* GADMediationVungleRewardedAd.m in Sources */,
 				458F73502385DFF2006738A0 /* GADMAdapterVungleRouter.m in Sources */,
 				45BFFB5A22272D1000C96A67 /* GADMediationAdapterVungle.m in Sources */,
 				A85428E51F11853A00C135E7 /* VungleAdNetworkExtras.m in Sources */,
-				45BFFB5E22272D4300C96A67 /* GADMAdapterVungleRewardedAd.m in Sources */,
 				4552392A20B6381E0081388F /* VungleRouterConsent.m in Sources */,
-				A85428E11F11853A00C135E7 /* GADMAdapterVungleInterstitial.m in Sources */,
-				A85428E31F11853A00C135E7 /* GADMAdapterVungleRewardBasedVideoAd.m in Sources */,
+				176AE0DB2613E49C00E19EE8 /* GADMAdapterVungleRewardBasedVideoAd.m in Sources */,
+				176EA85B26E021EF00B492E0 /* GADMAdapterVungleBanner.m in Sources */,
 				407621A123F140B800C18557 /* VungleRouterConfiguration.m in Sources */,
 				4593F490227CE28A00F57AE5 /* GADMAdapterVungleUtils.m in Sources */,
 			);

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.h
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.h
@@ -21,7 +21,7 @@
     initWithAdConfiguration:(nonnull GADMediationBannerAdConfiguration *)adConfiguration
           completionHandler:(nonnull GADMediationBannerLoadCompletionHandler)handler;
 
-/// Unavailable.
+/// Constructor is unavailable. Please use initWithAdConfiguration:completionHandler:.
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
 /// Requests a banner ad from Vungle.

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.h
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,13 +15,19 @@
 #import <Foundation/Foundation.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-@interface GADMAdapterVungleRewardedAd : NSObject <GADMediationRewardedAd>
+@interface GADMediationVungleBanner : NSObject
 
 - (nonnull instancetype)
-    initWithAdConfiguration:(nonnull GADMediationRewardedAdConfiguration *)adConfiguration
-          completionHandler:(nonnull GADMediationRewardedLoadCompletionHandler)handler;
+    initWithAdConfiguration:(nonnull GADMediationBannerAdConfiguration *)adConfiguration
+          completionHandler:(nonnull GADMediationBannerLoadCompletionHandler)handler;
+
+/// Unavailable.
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-- (void)requestRewardedAd;
+/// Requests a banner ad from Vungle.
+- (void)requestBannerAd;
+
+/// Destroy and cleanup Vungle's banner ad.
+- (void)cleanUp;
 
 @end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
@@ -117,12 +117,13 @@
   if (size.height == kGADAdSizeBanner.size.height) {
     if (size.width < kGADAdSizeBanner.size.width) {
       return shortBannerSize;
-    } else {
-      return kGADAdSizeBanner;
     }
-  } else if (size.height == kGADAdSizeLeaderboard.size.height) {
+    return kGADAdSizeBanner;
+  }
+  if (size.height == kGADAdSizeLeaderboard.size.height) {
     return kGADAdSizeLeaderboard;
-  } else if (size.height == kGADAdSizeMediumRectangle.size.height) {
+  }
+  if (size.height == kGADAdSizeMediumRectangle.size.height) {
     return kGADAdSizeMediumRectangle;
   }
 

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
@@ -233,6 +233,7 @@
 
 - (void)trackClick {
   [_delegate reportClick];
+  [_delegate willPresentFullScreenView];
 }
 
 - (void)willLeaveApplication {

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleBanner.m
@@ -1,0 +1,245 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GADMediationVungleBanner.h"
+#include <stdatomic.h>
+#import "GADMAdapterVungleRouter.h"
+#import "GADMAdapterVungleUtils.h"
+
+@interface GADMediationVungleBanner () <GADMAdapterVungleDelegate, GADMediationBannerAd>
+@end
+
+@implementation GADMediationVungleBanner {
+  /// Ad configuration for the ad to be loaded.
+  GADMediationBannerAdConfiguration *_adConfiguration;
+
+  /// The completion handler to call when an ad loads successfully or fails.
+  GADMediationBannerLoadCompletionHandler _adLoadCompletionHandler;
+
+  /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
+  id<GADMediationBannerAdEventDelegate> _delegate;
+
+  /// The requested ad size.
+  GADAdSize _bannerSize;
+
+  /// Indicates whether a banner ad is loaded.
+  BOOL _isAdLoaded;
+
+  /// Indicates whether the banner ad finished presenting.
+  BOOL _didBannerFinishPresenting;
+}
+
+@synthesize desiredPlacement;
+@synthesize bannerState;
+@synthesize uniquePubRequestID;
+@synthesize isRefreshedForBannerAd;
+@synthesize isRequestingBannerAdForRefresh;
+@synthesize view;
+
+- (void)dealloc {
+    [self cleanUp];
+}
+
+- (nonnull instancetype)initWithAdConfiguration:(nonnull GADMediationBannerAdConfiguration*)adConfiguration
+                              completionHandler:(nonnull GADMediationBannerLoadCompletionHandler)completionHandler {
+  self = [super init];
+  if (self) {
+    _adConfiguration = adConfiguration;
+    _bannerSize = [self vungleAdSizeForAdSize:[adConfiguration adSize]];
+      
+    VungleAdNetworkExtras *networkExtras = adConfiguration.extras;
+    self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings networkExtras:networkExtras];
+    self.uniquePubRequestID = [networkExtras.UUID copy];
+
+    __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
+    __block GADMediationBannerLoadCompletionHandler origAdLoadHandler = [completionHandler copy];
+    /// Ensure the original completion handler is only called once, and is deallocated once called.
+    _adLoadCompletionHandler = ^id<GADMediationBannerAdEventDelegate>(
+      id<GADMediationBannerAd> ad, NSError *error) {
+      if (atomic_flag_test_and_set(&adLoadHandlerCalled)) {
+        return nil;
+      }
+      id<GADMediationBannerAdEventDelegate> delegate = nil;
+      if (origAdLoadHandler) {
+        delegate = origAdLoadHandler(ad, error);
+      }
+      origAdLoadHandler = nil;
+      return delegate;
+    };
+  }
+  return self;
+}
+
+- (void)requestBannerAd {
+  if (!IsGADAdSizeValid(_bannerSize)) {
+    NSString *errorMessage = [NSString stringWithFormat:@"Unsupported ad size requested for Vungle. Size: %@", NSStringFromGADAdSize(_bannerSize)];
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(GADMAdapterVungleErrorBannerSizeMismatch, errorMessage);
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+
+  if (!self.desiredPlacement.length) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(GADMAdapterVungleErrorInvalidServerParameters, @"Placement ID not specified.");
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+
+  if (![[GADMAdapterVungleRouter sharedInstance] isSDKInitialized]) {
+    NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
+    [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
+    return;
+  }
+
+  [self loadAd];
+}
+
+- (GADAdSize)vungleAdSizeForAdSize:(GADAdSize)adSize {
+  // An array of supported ad sizes.
+  GADAdSize shortBannerSize = GADAdSizeFromCGSize(kVNGBannerShortSize);
+  NSArray<NSValue *> *potentials = @[
+    NSValueFromGADAdSize(kGADAdSizeMediumRectangle), NSValueFromGADAdSize(kGADAdSizeBanner),
+    NSValueFromGADAdSize(kGADAdSizeLeaderboard), NSValueFromGADAdSize(shortBannerSize)
+  ];
+
+  GADAdSize closestSize = GADClosestValidSizeForAdSizes(adSize, potentials);
+  CGSize size = CGSizeFromGADAdSize(closestSize);
+  if (size.height == kGADAdSizeBanner.size.height) {
+    if (size.width < kGADAdSizeBanner.size.width) {
+      return shortBannerSize;
+    } else {
+      return kGADAdSizeBanner;
+    }
+  } else if (size.height == kGADAdSizeLeaderboard.size.height) {
+    return kGADAdSizeLeaderboard;
+  } else if (size.height == kGADAdSizeMediumRectangle.size.height) {
+    return kGADAdSizeMediumRectangle;
+  }
+
+  return kGADAdSizeInvalid;
+}
+
+- (void)loadAd {
+  NSError *error = [[GADMAdapterVungleRouter sharedInstance] loadAd:self.desiredPlacement
+                                                       withDelegate:self];
+  if (error) {
+    _adLoadCompletionHandler(nil, error);
+  }
+}
+
+- (void)loadFrame {
+  view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, _bannerSize.size.width, _bannerSize.size.height)];
+}
+
+- (NSError *)renderAd {
+  return [[GADMAdapterVungleRouter sharedInstance] renderBannerAdInView:view
+                                                               delegate:self
+                                                                 extras:[_adConfiguration extras]
+                                                         forPlacementID:self.desiredPlacement];
+}
+
+- (void)cleanUp {
+  if (_didBannerFinishPresenting) {
+    return;
+  }
+  _didBannerFinishPresenting = YES;
+
+  [[GADMAdapterVungleRouter sharedInstance] completeBannerAdViewForPlacementID:self];
+  [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
+  view = nil;
+}
+
+#pragma mark - GADMAdapterVungleDelegate delegates
+
+- (NSString *)bidResponse {
+    return [_adConfiguration bidResponse];
+}
+
+- (GADAdSize)bannerAdSize {
+  return _bannerSize;
+}
+
+- (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
+  if (!isSuccess) {
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+  [self loadAd];
+}
+
+- (void)adAvailable {
+  if (_isAdLoaded) {
+    // Already invoked an ad load callback.
+    return;
+  }
+  _isAdLoaded = YES;
+  [self loadFrame];
+    
+  if (_adLoadCompletionHandler) {
+    _delegate = _adLoadCompletionHandler(self, nil);
+  }
+
+  if (!_delegate) {
+    [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
+    return;
+  }
+    
+  self.bannerState = BannerRouterDelegateStateWillPlay;
+  NSError *error = [self renderAd];
+  if (error) {
+    [_delegate didFailToPresentWithError:error];
+    return;
+  }
+}
+
+- (void)adNotAvailable:(nonnull NSError *)error {
+  if (_isAdLoaded) {
+    // Already invoked an ad load callback.
+    return;
+  }
+  _adLoadCompletionHandler(nil, error);
+}
+
+- (void)willShowAd {
+  self.bannerState = BannerRouterDelegateStatePlaying;
+}
+
+- (void)didViewAd {
+  // Do nothing.
+}
+
+- (void)willCloseAd {
+  self.bannerState = BannerRouterDelegateStateClosing;
+  // This callback is fired when the banner itself is destroyed/removed, not when the user returns
+  // to the app screen after clicking on an ad. Do not map to adViewWillDismissScreen:.
+}
+
+- (void)didCloseAd {
+  self.bannerState = BannerRouterDelegateStateClosed;
+  // This callback is fired when the banner itself is destroyed/removed, not when the user returns
+  // to the app screen after clicking on an ad. Do not map to adViewDidDismissScreen:.
+}
+
+- (void)trackClick {
+  [_delegate reportClick];
+}
+
+- (void)willLeaveApplication {
+  [_delegate willBackgroundApplication];
+}
+
+- (void)rewardUser {
+  // Do nothing.
+}
+
+@end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.h
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.h
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "GADMAdapterVungleRewardBasedVideoAd.h"
-#import "GADMediationAdapterVungle.h"
+#import <Foundation/Foundation.h>
+#import <GoogleMobileAds/GoogleMobileAds.h>
 
-@implementation GADMAdapterVungleRewardBasedVideoAd
+@interface GADMediationVungleInterstitial : NSObject
 
-/// TODO(Google): Remove this class once Google's server points to GADMediationAdapterVungle
-/// directly to ask for a rewarded ad.
+- (nonnull instancetype)
+    initWithAdConfiguration:(nonnull GADMediationInterstitialAdConfiguration *)adConfiguration
+          completionHandler:(nonnull GADMediationInterstitialLoadCompletionHandler)handler;
 
-+ (nonnull Class<GADMediationAdapter>)mainAdapterClass {
-  return [GADMediationAdapterVungle class];
-}
+/// Unavailable.
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+/// Requests a interstitial ad from Vungle.
+- (void)requestInterstitialAd;
 
 @end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.h
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.h
@@ -21,7 +21,7 @@
     initWithAdConfiguration:(nonnull GADMediationInterstitialAdConfiguration *)adConfiguration
           completionHandler:(nonnull GADMediationInterstitialLoadCompletionHandler)handler;
 
-/// Unavailable.
+/// Constructor is unavailable. Please use initWithAdConfiguration:completionHandler:.
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
 /// Requests a interstitial ad from Vungle.

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -1,0 +1,187 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GADMediationVungleInterstitial.h"
+#include <stdatomic.h>
+#import "GADMAdapterVungleConstants.h"
+#import "GADMAdapterVungleRouter.h"
+#import "GADMAdapterVungleUtils.h"
+
+@interface GADMediationVungleInterstitial () <GADMAdapterVungleDelegate, GADMediationInterstitialAd>
+@end
+
+@implementation GADMediationVungleInterstitial {
+  /// Ad configuration for the ad to be loaded.
+  GADMediationInterstitialAdConfiguration *_adConfiguration;
+
+  /// The completion handler to call when an ad loads successfully or fails.
+  GADMediationInterstitialLoadCompletionHandler _adLoadCompletionHandler;
+
+  /// The ad event delegate to forward ad rendering events to the Google Mobile Ads SDK.
+  id<GADMediationInterstitialAdEventDelegate> _delegate;
+
+  /// Indicates whether an interstitial ad is loaded.
+  BOOL _isAdLoaded;
+}
+
+@synthesize desiredPlacement;
+
+#pragma mark - GADMediationVungleInterstitial Methods
+
+- (nonnull instancetype)initWithAdConfiguration:(nonnull GADMediationInterstitialAdConfiguration*)adConfiguration
+                              completionHandler:(nonnull GADMediationInterstitialLoadCompletionHandler)completionHandler {
+  self = [super init];
+  if (self) {
+    _adConfiguration = adConfiguration;
+    self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings networkExtras:adConfiguration.extras];
+
+    __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
+    __block GADMediationInterstitialLoadCompletionHandler origAdLoadHandler = [completionHandler copy];
+
+    /// Ensure the original completion handler is only called once, and is deallocated once called.
+    _adLoadCompletionHandler = ^id<GADMediationInterstitialAdEventDelegate>(
+      id<GADMediationInterstitialAd> ad, NSError *error) {
+      if (atomic_flag_test_and_set(&adLoadHandlerCalled)) {
+        return nil;
+      }
+      id<GADMediationInterstitialAdEventDelegate> delegate = nil;
+      if (origAdLoadHandler) {
+        delegate = origAdLoadHandler(ad, error);
+      }
+      origAdLoadHandler = nil;
+      return delegate;
+    };
+  }
+  return self;
+}
+
+- (void)requestInterstitialAd {
+  if (!self.desiredPlacement.length) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
+      GADMAdapterVungleErrorInvalidServerParameters,
+      @"Placement ID not specified.");
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+
+  if ([[GADMAdapterVungleRouter sharedInstance] hasDelegateForPlacementID:self.desiredPlacement]) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
+        GADMAdapterVungleErrorAdAlreadyLoaded,
+        @"Only a maximum of one ad per placement can be requested from Vungle.");
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+
+  if (![[GADMAdapterVungleRouter sharedInstance] isSDKInitialized]) {
+    NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
+    [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
+    return;
+  }
+
+  [self loadAd];
+}
+
+#pragma mark - GADMediationInterstitialAd Methods
+
+- (void)presentFromViewController:(UIViewController *)rootViewController {
+  NSError *error = nil;
+  if (![[GADMAdapterVungleRouter sharedInstance] playAd:rootViewController
+                                               delegate:self
+                                                 extras:[_adConfiguration extras]
+                                                  error:&error]) {
+    // Ad not playable.
+    if (error) {
+      [_delegate didFailToPresentWithError:error];
+    }
+  }
+}
+
+#pragma mark - Private methods
+
+- (void)loadAd {
+  NSError *error = [[GADMAdapterVungleRouter sharedInstance] loadAd:self.desiredPlacement
+                                                       withDelegate:self];
+  if (error) {
+    _adLoadCompletionHandler(nil, error);
+  }
+}
+
+#pragma mark - GADMAdapterVungleDelegate
+
+- (NSString *)bidResponse {
+    return [_adConfiguration bidResponse];
+}
+
+- (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
+  if (!isSuccess) {
+    _adLoadCompletionHandler(nil, error);
+    return;
+  }
+  [self loadAd];
+}
+
+- (void)adAvailable {
+  if (_isAdLoaded) {
+    // Already invoked an ad load callback.
+    return;
+  }
+  _isAdLoaded = YES;
+    
+  if (_adLoadCompletionHandler) {
+    _delegate = _adLoadCompletionHandler(self, nil);
+  }
+
+  if (!_delegate) {
+    // In this case, the request for Vungle has been timed out. Clean up self.
+    [[GADMAdapterVungleRouter sharedInstance] removeDelegate:self];
+  }
+}
+
+- (void)adNotAvailable:(nonnull NSError *)error {
+  if (_isAdLoaded) {
+    // Already invoked an ad load callback.
+    return;
+  }
+  _adLoadCompletionHandler(nil, error);
+}
+
+- (void)willShowAd {
+  [_delegate willPresentFullScreenView];
+}
+
+- (void)didViewAd {
+  // Do nothing.
+}
+
+- (void)willCloseAd {
+  [_delegate willDismissFullScreenView];
+}
+
+- (void)didCloseAd {
+  [_delegate didDismissFullScreenView];
+}
+
+- (void)trackClick {
+  [_delegate reportClick];
+}
+
+- (void)willLeaveApplication {
+  [_delegate willBackgroundApplication];
+}
+
+- (void)rewardUser {
+  // Do nothing.
+}
+
+@end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.h
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.h
@@ -20,8 +20,11 @@
 - (nonnull instancetype)
     initWithAdConfiguration:(nonnull GADMediationRewardedAdConfiguration *)adConfiguration
           completionHandler:(nonnull GADMediationRewardedLoadCompletionHandler)handler;
+
+/// Constructor is unavailable. Please use initWithAdConfiguration:completionHandler:.
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
+/// Requests a rewarded ad from Vungle.
 - (void)requestRewardedAd;
 
 @end

--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.h
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleRewardedAd.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "GADMAdapterVungleRewardBasedVideoAd.h"
-#import "GADMediationAdapterVungle.h"
+#import <Foundation/Foundation.h>
+#import <GoogleMobileAds/GoogleMobileAds.h>
 
-@implementation GADMAdapterVungleRewardBasedVideoAd
+@interface GADMediationVungleRewardedAd : NSObject <GADMediationRewardedAd>
 
-/// TODO(Google): Remove this class once Google's server points to GADMediationAdapterVungle
-/// directly to ask for a rewarded ad.
+- (nonnull instancetype)
+    initWithAdConfiguration:(nonnull GADMediationRewardedAdConfiguration *)adConfiguration
+          completionHandler:(nonnull GADMediationRewardedLoadCompletionHandler)handler;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
-+ (nonnull Class<GADMediationAdapter>)mainAdapterClass {
-  return [GADMediationAdapterVungle class];
-}
+- (void)requestRewardedAd;
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
@@ -146,6 +146,11 @@
   return _bannerSize;
 }
 
+- (nullable NSString *)bidResponse {
+    // This is the waterfall interstitial section. It won't have a bid response
+    return nil;
+}
+
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
   if (!isSuccess) {
     [_connector adapter:_adapter didFailAd:error];
@@ -221,5 +226,6 @@
 - (void)rewardUser {
   // Do nothing.
 }
+
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
@@ -217,6 +217,7 @@
 
 - (void)trackClick {
   [_connector adapterDidGetAdClick:_adapter];
+  [_connector adapterWillPresentFullScreenModal:_adapter];
 }
 
 - (void)willLeaveApplication {

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleBanner.m
@@ -147,7 +147,7 @@
 }
 
 - (nullable NSString *)bidResponse {
-    // This is the waterfall interstitial section. It won't have a bid response
+    // This is the waterfall banner section. It won't have a bid response.
     return nil;
 }
 
@@ -226,6 +226,5 @@
 - (void)rewardUser {
   // Do nothing.
 }
-
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.5.0";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.5.1";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -29,6 +29,9 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 /// Placement ID used to request an ad from Vungle.
 @property(nonatomic, copy, nonnull) NSString *desiredPlacement;
 
+/// Bid Response when the ad is instantiated. May be null if Open Bidding is not enabled.
+- (nullable NSString *)bidResponse;
+
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error;
 - (void)adAvailable;
 - (void)adNotAvailable:(nonnull NSError *)error;

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleDelegate.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSUInteger, BannerRouterDelegateState) {
 /// Placement ID used to request an ad from Vungle.
 @property(nonatomic, copy, nonnull) NSString *desiredPlacement;
 
-/// Bid Response when the ad is instantiated. May be null if Open Bidding is not enabled.
+/// Bid Response when the ad is instantiated. May be null if bidding is not enabled.
 - (nullable NSString *)bidResponse;
 
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error;

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -17,6 +17,7 @@
 #import "GADMAdapterVungleConstants.h"
 #import "GADMAdapterVungleRouter.h"
 #import "GADMAdapterVungleUtils.h"
+#import "GADMediationAdapterVungle.h"
 
 @interface GADMAdapterVungleInterstitial () <GADMAdapterVungleDelegate>
 @end
@@ -30,6 +31,12 @@
 
   /// Indicates whether an interstitial ad is loaded.
   BOOL _isAdLoaded;
+}
+
+// Redirect to the main adapter class for bidding
+// but still implement GADMAdNetworkAdapter for waterfall
++ (nonnull Class<GADMediationAdapter>)mainAdapterClass {
+  return [GADMediationAdapterVungle class];
 }
 
 + (nullable Class<GADAdNetworkExtras>)networkExtrasClass {
@@ -136,9 +143,14 @@
   }
 }
 
-#pragma mark - VungleRouter delegates
+#pragma mark - GADMAdapterVungleDelegate
 
 @synthesize desiredPlacement;
+
+- (nullable NSString *)bidResponse {
+    // This is the waterfall interstitial section. It won't have a bid response
+    return nil;
+}
 
 - (void)initialized:(BOOL)isSuccess error:(nullable NSError *)error {
   if (!isSuccess) {
@@ -194,5 +206,6 @@
 - (void)rewardUser {
   // Do nothing.
 }
+
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleInterstitial.m
@@ -34,7 +34,7 @@
 }
 
 // Redirect to the main adapter class for bidding
-// but still implement GADMAdNetworkAdapter for waterfall
+// but still implement GADMAdNetworkAdapter for waterfall.
 + (nonnull Class<GADMediationAdapter>)mainAdapterClass {
   return [GADMediationAdapterVungle class];
 }
@@ -206,6 +206,5 @@
 - (void)rewardUser {
   // Do nothing.
 }
-
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardBasedVideoAd.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardBasedVideoAd.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardBasedVideoAd.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardBasedVideoAd.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2019-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardBasedVideoAd.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRewardBasedVideoAd.m
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2019-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.h
@@ -19,7 +19,7 @@
 
 extern const CGSize kVNGBannerShortSize;
 
-@interface GADMAdapterVungleRouter : NSObject <VungleSDKDelegate>
+@interface GADMAdapterVungleRouter : NSObject <VungleSDKDelegate, VungleSDKHBDelegate>
 
 + (nonnull GADMAdapterVungleRouter *)sharedInstance;
 - (void)initWithAppId:(nonnull NSString *)appId
@@ -37,5 +37,7 @@ extern const CGSize kVNGBannerShortSize;
                                     extras:(nullable VungleAdNetworkExtras *)extras
                             forPlacementID:(nonnull NSString *)placementID;
 - (void)completeBannerAdViewForPlacementID:(nonnull id<GADMAdapterVungleDelegate>)delegate;
+- (BOOL)isSDKInitialized;
+- (nullable NSString *)getSuperToken;
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -172,7 +172,8 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
             delegate.uniquePubRequestID ?: kGADMAdapterVungleNullPubRequestID);
         return YES;
       } else if ([_bannerDelegates objectForKey:delegate.desiredPlacement]) {
-        id<GADMAdapterVungleDelegate> bannerDelegate = [_bannerDelegates objectForKey:delegate.desiredPlacement];
+        id<GADMAdapterVungleDelegate> bannerDelegate =
+          [_bannerDelegates objectForKey:delegate.desiredPlacement];
         if ([bannerDelegate.uniquePubRequestID isEqualToString:delegate.uniquePubRequestID]) {
           /* The isRequestingBannerAdForRefresh flag is used for an edge case, when the old Banner
            * delegate is removed from _bannerDelegates and there is a refresh Banner delegate

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -16,6 +16,7 @@
 #import "GADMAdapterVungleConstants.h"
 #import "GADMAdapterVungleUtils.h"
 #import "VungleRouterConsent.h"
+#import <VungleSDK/VungleSDKHeaderBidding.h>
 
 const CGSize kVNGBannerShortSize = {300, 50};
 
@@ -54,6 +55,7 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   self = [super init];
   if (self) {
     [VungleSDK sharedSDK].delegate = self;
+    [VungleSDK sharedSDK].sdkHBDelegate = self;
     _delegates = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
                                        valueOptions:NSPointerFunctionsWeakMemory];
     _initializingDelegates = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsStrongMemory
@@ -93,11 +95,18 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   if (_isInitializing) {
     return;
   }
+    
+  if (!appId) {
+    NSError *error = GADMAdapterVungleErrorWithCodeAndDescription(
+      GADMAdapterVungleErrorInvalidServerParameters, @"Vungle app ID not specified.");
+    [delegate initialized:NO error:error];
+    return;
+  }
 
   _isInitializing = YES;
 
   // Disable refresh functionality for all banners
-  [[VungleSDK sharedSDK] disableBannerRefresh];
+  [sdk disableBannerRefresh];
 
   // Enable background downloading
   [VungleSDK enableBackgroundDownload:YES];
@@ -145,11 +154,11 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
     // as opposed to isAdCachedForPlacementID:withSize:.
     if (!GADAdSizeEqualToSize(adSize, kGADAdSizeMediumRectangle)) {
       VungleAdSize vungleAdSize = GADMAdapterVungleAdSizeForCGSize(adSize.size);
-      return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID withSize:vungleAdSize];
+      return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID adMarkup:[delegate bidResponse] withSize:vungleAdSize];
     }
   }
 
-  return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID];
+  return [[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID adMarkup:[delegate bidResponse]];
 }
 
 - (BOOL)addDelegate:(nonnull id<GADMAdapterVungleDelegate>)delegate {
@@ -157,15 +166,13 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
     @synchronized(_bannerDelegates) {
       if (![_bannerDelegates objectForKey:delegate.desiredPlacement] &&
           ![_bannerRequestingDict objectForKey:delegate.desiredPlacement]) {
-        GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.desiredPlacement,
-                                                 delegate);
+        GADMAdapterVungleMapTableSetObjectForKey(_bannerDelegates, delegate.desiredPlacement, delegate);
         GADMAdapterVungleMutableDictionarySetObjectForKey(
             _bannerRequestingDict, delegate.desiredPlacement,
             delegate.uniquePubRequestID ?: kGADMAdapterVungleNullPubRequestID);
         return YES;
       } else if ([_bannerDelegates objectForKey:delegate.desiredPlacement]) {
-        id<GADMAdapterVungleDelegate> bannerDelegate =
-            [_bannerDelegates objectForKey:delegate.desiredPlacement];
+        id<GADMAdapterVungleDelegate> bannerDelegate = [_bannerDelegates objectForKey:delegate.desiredPlacement];
         if ([bannerDelegate.uniquePubRequestID isEqualToString:delegate.uniquePubRequestID]) {
           /* The isRequestingBannerAdForRefresh flag is used for an edge case, when the old Banner
            * delegate is removed from _bannerDelegates and there is a refresh Banner delegate
@@ -179,12 +186,12 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
         }
 
         if (!bannerDelegate.uniquePubRequestID) {
-          NSLog(@"Ad already loaded for placement ID: %@, and cannot determine if this is a "
+          NSLog(@"Vungle: Ad already loaded for placement ID: %@, and cannot determine if this is a "
                 @"refresh. Set Vungle extras when making an ad request to support refresh on "
                 @"Vungle banner ads.",
                 bannerDelegate.desiredPlacement);
         } else {
-          NSLog(@"Ad already loaded for placement ID: %@", bannerDelegate.desiredPlacement);
+          NSLog(@"Vungle: Ad already loaded for placement ID: %@", bannerDelegate.desiredPlacement);
         }
       }
     }
@@ -317,12 +324,12 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
     // as opposed to isAdCachedForPlacementID:withSize:.
     if (!GADAdSizeEqualToSize(adSize, kGADAdSizeMediumRectangle)) {
       VungleAdSize vungleAdSize = GADMAdapterVungleAdSizeForCGSize(adSize.size);
-      [sdk loadPlacementWithID:placement withSize:vungleAdSize error:&loadError];
+      [sdk loadPlacementWithID:placement adMarkup:[delegate bidResponse] withSize:vungleAdSize error:&loadError];
     } else {
-      [sdk loadPlacementWithID:placement error:&loadError];
+      [sdk loadPlacementWithID:placement adMarkup:[delegate bidResponse] error:&loadError];
     }
   } else {
-    [sdk loadPlacementWithID:placement error:&loadError];
+    [sdk loadPlacementWithID:placement adMarkup:[delegate bidResponse] error:&loadError];
   }
 
   return loadError;
@@ -368,6 +375,7 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   return [[VungleSDK sharedSDK] playAd:viewController
                                options:options
                            placementID:delegate.desiredPlacement
+                              adMarkup:[delegate bidResponse]
                                  error:error];
 }
 
@@ -401,6 +409,7 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   BOOL success = [[VungleSDK sharedSDK] addAdViewToView:bannerView
                                             withOptions:options
                                             placementID:placementID
+                                               adMarkup:[delegate bidResponse]
                                                   error:&bannerError];
   if (success) {
     // For a refresh banner delegate, if the Banner view is constructed successfully,
@@ -414,18 +423,14 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
 
 - (void)completeBannerAdViewForPlacementID:(nonnull id<GADMAdapterVungleDelegate>)delegate {
   @synchronized(self) {
-    if (!delegate) {
-      return;
-    }
-
-    if (![_bannerDelegates objectForKey:delegate.desiredPlacement]) {
+    if (!delegate || ![delegate respondsToSelector:@selector(bannerAdSize)]) {
       return;
     }
 
     if (delegate.bannerState == BannerRouterDelegateStatePlaying ||
         delegate.bannerState == BannerRouterDelegateStateWillPlay) {
       NSLog(@"Vungle: Triggering an ad completion call for %@", delegate.desiredPlacement);
-      [[VungleSDK sharedSDK] finishDisplayingAd:delegate.desiredPlacement];
+      [[VungleSDK sharedSDK] finishDisplayingAd:delegate.desiredPlacement adMarkup:[delegate bidResponse]];
     }
   }
 }
@@ -440,6 +445,10 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
 
   [_initializingDelegates removeAllObjects];
   _prioritizedPlacementID = nil;
+}
+
+- (NSString *)getSuperToken {
+    return [[VungleSDK sharedSDK] currentSuperToken];
 }
 
 #pragma mark - VungleSDKDelegate methods
@@ -521,7 +530,7 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   // Vungle SDK calls this method with isAdPlayable NO just after an ad is presented. These events
   // should be ignored as they aren't related to a load call. Assume an ad is presented if Vungle
   // SDK has an ad cached for this placement.
-  if ([[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID]) {
+  if ([[VungleSDK sharedSDK] isAdCachedForPlacementID:placementID adMarkup:[delegate bidResponse]]) {
     return;
   }
 
@@ -548,6 +557,49 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
 
 - (void)vungleSDKFailedToInitializeWithError:(nonnull NSError *)error {
   [self initialized:NO error:error];
+}
+
+#pragma mark - VungleSDKHBDelegate methods
+
+- (void)vungleAdPlayabilityUpdate:(BOOL)isAdPlayable placementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup error:(nullable NSError *)error {
+  [self vungleAdPlayabilityUpdate:isAdPlayable placementID:placementID error:error];
+}
+
+- (void)vungleWillShowAdForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleWillShowAdForPlacementID:placementID];
+}
+
+- (void)vungleDidShowAdForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleDidShowAdForPlacementID:placementID];
+}
+
+- (void)vungleAdViewedForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleAdViewedForPlacement:placementID];
+}
+
+- (void)vungleWillCloseAdForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleWillCloseAdForPlacementID:placementID];
+}
+
+- (void)vungleDidCloseAdForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleDidCloseAdForPlacementID:placementID];
+}
+
+- (void)vungleTrackClickForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleTrackClickForPlacementID:placementID];
+}
+
+- (void)vungleWillLeaveApplicationForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleWillLeaveApplicationForPlacementID:placementID];
+}
+
+- (void)vungleRewardUserForPlacementID:(nullable NSString *)placementID adMarkup:(nullable NSString *)adMarkup {
+  [self vungleRewardUserForPlacementID:placementID];
+}
+
+- (void)invalidateObjectsForPlacementID:(nullable NSString *)placementID {
+  id<GADMAdapterVungleDelegate> delegate = [self getDelegateForPlacement:placementID];
+  [self removeDelegate:delegate];
 }
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMediationAdapterVungle.h
+++ b/adapters/Vungle/VungleAdapter/GADMediationAdapterVungle.h
@@ -31,6 +31,6 @@ typedef NS_ENUM(NSInteger, GADMAdapterVungleErrorCode) {
   GADMAdapterVungleErrorAdNotPlayable = 106
 };
 
-@interface GADMediationAdapterVungle : NSObject <GADMediationAdapter>
+@interface GADMediationAdapterVungle : NSObject <GADRTBAdapter>
 
 @end

--- a/adapters/Vungle/VungleAdapter/GADMediationAdapterVungle.m
+++ b/adapters/Vungle/VungleAdapter/GADMediationAdapterVungle.m
@@ -14,14 +14,22 @@
 
 #import "GADMediationAdapterVungle.h"
 #import "GADMAdapterVungleConstants.h"
-#import "GADMAdapterVungleRewardedAd.h"
+#import "GADMediationVungleBanner.h"
+#import "GADMediationVungleInterstitial.h"
+#import "GADMediationVungleRewardedAd.h"
 #import "GADMAdapterVungleRouter.h"
 #import "GADMAdapterVungleUtils.h"
 #import "VungleAdNetworkExtras.h"
 
 @implementation GADMediationAdapterVungle {
   /// Vungle rewarded ad wrapper.
-  GADMAdapterVungleRewardedAd *_rewardedAd;
+  GADMediationVungleRewardedAd *_rewardedAd;
+    
+  /// Vungle interstitial ad wrapper.
+  GADMediationVungleInterstitial *_interstitialAd;
+    
+  /// Vungle banner ad wrapper.
+  GADMediationVungleBanner *_bannerAd;
 }
 
 + (void)setUpWithConfiguration:(nonnull GADMediationServerConfiguration *)configuration
@@ -89,9 +97,30 @@
             (nonnull GADMediationRewardedAdConfiguration *)adConfiguration
                        completionHandler:
                            (nonnull GADMediationRewardedLoadCompletionHandler)completionHandler {
-  _rewardedAd = [[GADMAdapterVungleRewardedAd alloc] initWithAdConfiguration:adConfiguration
+  _rewardedAd = [[GADMediationVungleRewardedAd alloc] initWithAdConfiguration:adConfiguration
                                                            completionHandler:completionHandler];
   [_rewardedAd requestRewardedAd];
+}
+
+- (void)loadInterstitialForAdConfiguration:(nonnull GADMediationInterstitialAdConfiguration *)adConfiguration
+                         completionHandler:(nonnull GADMediationInterstitialLoadCompletionHandler)completionHandler {
+    _interstitialAd = [[GADMediationVungleInterstitial alloc] initWithAdConfiguration:adConfiguration
+                                                                    completionHandler:completionHandler];
+    [_interstitialAd requestInterstitialAd];
+}
+
+- (void)loadBannerForAdConfiguration:(nonnull GADMediationBannerAdConfiguration *)adConfiguration
+                   completionHandler:(nonnull GADMediationBannerLoadCompletionHandler)completionHandler {
+    _bannerAd = [[GADMediationVungleBanner alloc] initWithAdConfiguration:adConfiguration
+                                                        completionHandler:completionHandler];
+    [_bannerAd requestBannerAd];
+}
+
+#pragma mark GADRTBAdapter implementation
+
+- (void)collectSignalsForRequestParameters:(nonnull GADRTBRequestParameters *)params
+                         completionHandler:(nonnull GADRTBSignalCompletionHandler)completionHandler {
+    completionHandler([[GADMAdapterVungleRouter sharedInstance] getSuperToken], nil);
 }
 
 @end


### PR DESCRIPTION
Adding the Open Bidding implementation to the AdMob adapter. GADMediationAdapterVungle now implements GADRTBAdapter instead of GADMediationAdapter. The VungleRouter implements the new VungleSDKHBDelegate. The Banner and Interstitial classes now implement their respective Mediation classes. The old interstitial class needs to remain as a router to the real adapter class, similar to the old rewarded class. The new ad format classes are moved under "Bidding". The legacy classes remain for waterfall cases. (#33)

Adding the Open Bidding implementation to the AdMob adapter. GADMediationAdapterVungle now implements GADRTBAdapter instead of GADMediationAdapter. The VungleRouter implements the new VungleSDKHBDelegate. The Banner and Interstitial classes now implement their respective Mediation classes. The old interstitial class needs to remain as a router to the real adapter class, similar to the old rewarded class. The new ad format classes are moved under "Bidding". The legacy classes remain for waterfall cases.