### PR TITLE
Update adapter for Chartboost 8.5.0

### DIFF
--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostConstants.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 
 /// Chartboost mediation network adapter version.
-static NSString *const kGADMAdapterChartboostVersion = @"8.4.2.0";
+static NSString *const kGADMAdapterChartboostVersion = @"8.5.0.0";
 
 /// Chartboost App ID.
 static NSString *const kGADMAdapterChartboostAppID = @"appId";


### PR DESCRIPTION
Just a string version update.
No changes in Chartboost SDK public API nor integration requirements.