### PR TITLE
Vungle mediation adapter 6.10.3.1 release

### DIFF
--- a/adapters/InMobi/CHANGELOG.md
+++ b/adapters/InMobi/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## InMobi iOS Mediation Adapter Changelog
 
-#### Version 10.0.0.0 (In Progress)
+#### [Version 10.0.0.0](https://dl.google.com/googleadmobadssdk/mediation/ios/inmobi/InMobiAdapter-10.0.0.0.zip)
 - Verified compatibility with InMobi SDK 10.0.0.
 - Now requires minimum iOS version 10.0.
 

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.3.0";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.3.1";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -332,34 +332,34 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
       delegate:(nonnull id<GADMAdapterVungleDelegate>)delegate
         extras:(nullable VungleAdNetworkExtras *)extras
          error:(NSError *_Nullable __autoreleasing *_Nullable)error {
-  NSMutableDictionary *options = [[NSMutableDictionary alloc] init];
-  [VungleSDK sharedSDK].muted = extras.muted;
-  if (extras.userId) {
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
-                                                      extras.userId);
-  }
-
-  if (extras.ordinal) {
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyOrdinal,
-                                                      @(extras.ordinal));
-  }
-
-  if (extras.flexViewAutoDismissSeconds) {
-    GADMAdapterVungleMutableDictionarySetObjectForKey(
-        options, VunglePlayAdOptionKeyFlexViewAutoDismissSeconds,
-        @(extras.flexViewAutoDismissSeconds));
-  }
-
-  if (extras.orientations) {
-    int appOrientation = [extras.orientations intValue];
-    NSNumber *orientations = @(UIInterfaceOrientationMaskAll);
-    if (appOrientation == 1) {
-      orientations = @(UIInterfaceOrientationMaskLandscape);
-    } else if (appOrientation == 2) {
-      orientations = @(UIInterfaceOrientationMaskPortrait);
+  NSMutableDictionary *options = nil;
+  if (extras) {
+    options = [[NSMutableDictionary alloc] init];
+    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                      @(extras.muted));
+    if (extras.userId) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
+                                                        extras.userId);
     }
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyOrientations,
-                                                      orientations);
+    if (extras.ordinal) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyOrdinal,
+                                                        @(extras.ordinal));
+    }
+    if (extras.flexViewAutoDismissSeconds) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyFlexViewAutoDismissSeconds,
+                                                        @(extras.flexViewAutoDismissSeconds));
+    }
+    if (extras.orientations) {
+      int appOrientation = [extras.orientations intValue];
+      NSNumber *orientations = @(UIInterfaceOrientationMaskAll);
+      if (appOrientation == 1) {
+        orientations = @(UIInterfaceOrientationMaskLandscape);
+      } else if (appOrientation == 2) {
+        orientations = @(UIInterfaceOrientationMaskPortrait);
+      }
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyOrientations,
+                                                        orientations);
+    }
   }
 
   return [[VungleSDK sharedSDK] playAd:viewController
@@ -372,24 +372,23 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
                                   delegate:(nonnull id<GADMAdapterVungleDelegate>)delegate
                                     extras:(nullable VungleAdNetworkExtras *)extras
                             forPlacementID:(nonnull NSString *)placementID {
-  NSMutableDictionary *options = [[NSMutableDictionary alloc] init];
-  if (extras != nil) {
-    [VungleSDK sharedSDK].muted = extras.muted;
-  } else {
-    [VungleSDK sharedSDK].muted = YES;
-  }
-  if (extras.userId) {
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
-                                                      extras.userId);
-  }
-  if (extras.ordinal) {
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyOrdinal,
-                                                      @(extras.ordinal));
-  }
-  if (extras.flexViewAutoDismissSeconds) {
-    GADMAdapterVungleMutableDictionarySetObjectForKey(
-        options, VunglePlayAdOptionKeyFlexViewAutoDismissSeconds,
-        @(extras.flexViewAutoDismissSeconds));
+  NSMutableDictionary *options = nil;
+  if (extras) {
+    options = [[NSMutableDictionary alloc] init];
+    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                      @(extras.muted));
+    if (extras.userId) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
+                                                        extras.userId);
+    }
+    if (extras.ordinal) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyOrdinal,
+                                                        @(extras.ordinal));
+    }
+    if (extras.flexViewAutoDismissSeconds) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyFlexViewAutoDismissSeconds,
+                                                        @(extras.flexViewAutoDismissSeconds));
+    }
   }
 
   NSError *bannerError = nil;


### PR DESCRIPTION
* Fixes issue with interstitial callbacks not firing after first playback
* Fixes issue with overriding SDK global mute in the adapter, if the publisher decides to assign a value directly.