### PR TITLE
Vungle mediation adapter 6.10.4.0 release

### DIFF
--- a/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
+++ b/adapters/Vungle/Public/Headers/VungleAdNetworkExtras.h
@@ -41,4 +41,6 @@
 
 @property(nonatomic, copy, readonly) NSString *_Nonnull UUID;
 
+@property (nonatomic, readonly, assign) BOOL muteIsSet;
+
 @end

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.3.1";
+static NSString *const _Nonnull kGADMAdapterVungleVersion = @"6.10.4.0";
 static NSString *const _Nonnull kGADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull kGADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull kGADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/Vungle/VungleAdapter/GADMAdapterVungleRouter.m
@@ -335,8 +335,11 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSMutableDictionary *options = nil;
   if (extras) {
     options = [[NSMutableDictionary alloc] init];
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
-                                                      @(extras.muted));
+      
+    if (extras.muteIsSet) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                        @(extras.muted));
+    }
     if (extras.userId) {
       GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
                                                         extras.userId);
@@ -375,8 +378,10 @@ static NSString *const _Nonnull kGADMAdapterVungleNullPubRequestID = @"null";
   NSMutableDictionary *options = nil;
   if (extras) {
     options = [[NSMutableDictionary alloc] init];
-    GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
-                                                      @(extras.muted));
+    if (extras.muteIsSet) {
+      GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyStartMuted,
+                                                        @(extras.muted));
+    }
     if (extras.userId) {
       GADMAdapterVungleMutableDictionarySetObjectForKey(options, VunglePlayAdOptionKeyUser,
                                                         extras.userId);

--- a/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
+++ b/adapters/Vungle/VungleAdapter/VungleAdNetworkExtras.m
@@ -14,14 +14,34 @@
 
 #import "VungleAdNetworkExtras.h"
 
+@interface VungleAdNetworkExtras ()
+
+@property (readwrite, assign) BOOL muteIsSet;
+
+@end
+
 @implementation VungleAdNetworkExtras
+
+@synthesize muted = _muted;
 
 - (nonnull instancetype)init {
   self = [super init];
   if (self) {
     _UUID = [[NSUUID UUID] UUIDString];
+    _muteIsSet = NO;
   }
   return self;
+}
+
+-(BOOL)muted
+{
+    return _muted;
+}
+
+-(void)setMuted:(BOOL)muted
+{
+    _muted = muted;
+    self.muteIsSet = YES;
 }
 
 @end


### PR DESCRIPTION
- Verified compatibility with Vungle SDK 6.10.4.
- Fixed issue with the adapter not respecting muted settings on the dashboard when the boolean in networkExtras is not explicitly set.