### PR TITLE
[Vungle] This commit will add implementation for the optional methods for native ad 

### DIFF
--- a/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/Vungle/VungleAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -184,6 +184,14 @@
   [_nativeAd unregisterView];
 }
 
+- (BOOL)handlesUserClicks {
+  return YES;
+}
+
+- (BOOL)handlesUserImpressions {
+  return YES;
+}
+
 #pragma mark - VungleNativeAdDelegate
 
 - (void)nativeAdDidLoad:(VungleNativeAd *)nativeAd {


### PR DESCRIPTION
This commit will add implementation for the optional methods `handlesUserClicks` and `handlesUserImpressions` for native ad as requested by Google.