### PR TITLE
Add arm64 arch for IronSourceAdapter xcframework

### DIFF
--- a/adapters/IronSource/BuildScript/Script_Framework.sh
+++ b/adapters/IronSource/BuildScript/Script_Framework.sh
@@ -49,7 +49,7 @@ createFramework() {
 }
 
 createFramework "iphoneos" "armv7 arm64"
-createFramework "iphonesimulator" "x86_64"
+createFramework "iphonesimulator" "x86_64 arm64"
 
 # Create dynamic framework using the frameworks generated above.
 xcodebuild -create-xcframework \


### PR DESCRIPTION
Since IronSource 2.6.0 adds support of arm64 arch for simulator - add it for adapter