### PR TITLE
fix GADPortraitInlineAdaptiveBannerAdSizeWithWidth() banner invalid size

### DIFF
--- a/adapters/Pangle/PangleAdapter/Bidding/GADPangleRTBBannerRenderer.m
+++ b/adapters/Pangle/PangleAdapter/Bidding/GADPangleRTBBannerRenderer.m
@@ -111,7 +111,7 @@
   } else if (size.height == kPAGBannerSize300x250.size.height) {
     return kPAGBannerSize300x250;
   }
-  return kPAGBannerSize300x250;
+  return kPAGBannerSize320x50;
 }
 
 #pragma mark - GADMediationBannerAd

--- a/adapters/Pangle/PangleAdapter/Bidding/GADPangleRTBBannerRenderer.m
+++ b/adapters/Pangle/PangleAdapter/Bidding/GADPangleRTBBannerRenderer.m
@@ -60,13 +60,7 @@
     return;
   }
 
-  NSError *error = nil;
-  PAGBannerAdSize bannerSize = [self bannerSizeFormGADAdSize:adConfiguration.adSize error:&error];
-  if (error) {
-    _loadCompletionHandler(nil, error);
-    return;
-  }
-
+  PAGBannerAdSize bannerSize = [self bannerSizeFormGADAdSize:adConfiguration.adSize];
   PAGBannerRequest *request = [PAGBannerRequest requestWithBannerSize:bannerSize];
   request.adString = adConfiguration.bidResponse;
 
@@ -97,7 +91,7 @@
               }];
 }
 
-- (PAGBannerAdSize)bannerSizeFormGADAdSize:(GADAdSize)gadAdSize error:(NSError **)error {
+- (PAGBannerAdSize)bannerSizeFormGADAdSize:(GADAdSize)gadAdSize {
   CGSize gadAdCGSize = CGSizeFromGADAdSize(gadAdSize);
   GADAdSize banner50 = GADAdSizeFromCGSize(
       CGSizeMake(gadAdCGSize.width, kPAGBannerSize320x50.size.height));  // 320*50
@@ -117,14 +111,7 @@
   } else if (size.height == kPAGBannerSize300x250.size.height) {
     return kPAGBannerSize300x250;
   }
-
-  if (error) {
-    *error = GADMAdapterPangleErrorWithCodeAndDescription(
-        GADPangleErrorBannerSizeMismatch,
-        [NSString stringWithFormat:@"Invalid size for Pangle mediation adapter. Size: %@",
-                                   NSStringFromGADAdSize(gadAdSize)]);
-  }
-  return (PAGBannerAdSize){CGSizeZero};
+  return kPAGBannerSize300x250;
 }
 
 #pragma mark - GADMediationBannerAd


### PR DESCRIPTION
fix "Error: Error Domain=com.google.admob Code=9 "Request Error: No ad to show from all configured ad networks." UserInfo={NSLocalizedDescription=Request Error: No ad to show from all configured ad networks., NSUnderlyingError=0x280ce6d60 {Error Domain=com.google.mediation.pangle Code=102 "Invalid size for Pangle mediation adapter. Size: GADAdSize: {414, 0}, 80" UserInfo={NSLocalizedDescription=Invalid size for Pangle mediation adapter. Size: GADAdSize: {414, 0}, 80, NSLocalizedFailureReason=Invalid size for Pangle"