### PR TITLE
DTExchange 8.2.0 version support

### DIFF
--- a/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberConstants.h
+++ b/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberConstants.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 /// DT Exchange mediation adapter version.
 static NSString* const _Nonnull GADMAdapterFyberVersion = @"8.2.0.0";
 

--- a/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberRewardedAd.m
+++ b/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberRewardedAd.m
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <CoreLocation/CoreLocation.h>
 #import <IASDKCore/IASDKCore.h>
 
 #include <stdatomic.h>

--- a/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
+++ b/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
@@ -72,7 +72,7 @@ IAAdRequest *_Nonnull GADMAdapterFyberBuildRequestWithSpotIDAndAdConfiguration(
     builder.spotID = spotID;
     builder.timeout = 10;
     builder.userData = extras.userData;
-    builder.muteAudio = extras.muteAudio;
+    IASDKCore.sharedInstance.muteAudio = extras.muteAudio;
     if (keywords) {
       builder.keywords = keywords;
     }

--- a/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
+++ b/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
@@ -58,21 +58,18 @@ GADVersionNumber GADMAdapterFyberVersionFromString(NSString *_Nonnull versionStr
 IAAdRequest *_Nonnull GADMAdapterFyberBuildRequestWithSpotIDAndAdConfiguration(
     NSString *_Nonnull spotID, GADMediationRewardedAdConfiguration *_Nonnull adConfiguration) {
   GADMAdapterFyberExtras *extras = adConfiguration.extras;
-  NSString *keywords = nil;
+    
+  IASDKCore.sharedInstance.userData = extras.userData;
+  IASDKCore.sharedInstance.muteAudio = extras.muteAudio;
 
   if (extras.keywords) {
-    keywords = extras.keywords;
+    IASDKCore.sharedInstance.keywords = extras.keywords;
   }
 
   IAAdRequest *request = [IAAdRequest build:^(id<IAAdRequestBuilder> _Nonnull builder) {
     builder.useSecureConnections = NO;
     builder.spotID = spotID;
     builder.timeout = 10;
-    builder.userData = extras.userData;
-    IASDKCore.sharedInstance.muteAudio = extras.muteAudio;
-    if (keywords) {
-      builder.keywords = keywords;
-    }
   }];
 
   return request;

--- a/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
+++ b/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <CoreLocation/CoreLocation.h>
-
 #import "GADMAdapterFyberConstants.h"
 #import "GADMAdapterFyberExtras.h"
 #import "GADMAdapterFyberUtils.h"
@@ -59,7 +57,6 @@ GADVersionNumber GADMAdapterFyberVersionFromString(NSString *_Nonnull versionStr
 
 IAAdRequest *_Nonnull GADMAdapterFyberBuildRequestWithSpotIDAndAdConfiguration(
     NSString *_Nonnull spotID, GADMediationRewardedAdConfiguration *_Nonnull adConfiguration) {
-  CLLocation *location;
   GADMAdapterFyberExtras *extras = adConfiguration.extras;
   NSString *keywords = nil;
 
@@ -75,9 +72,6 @@ IAAdRequest *_Nonnull GADMAdapterFyberBuildRequestWithSpotIDAndAdConfiguration(
     IASDKCore.sharedInstance.muteAudio = extras.muteAudio;
     if (keywords) {
       builder.keywords = keywords;
-    }
-    if (location) {
-      builder.location = location;
     }
   }];
 


### PR DESCRIPTION
@joshh-devrel please approve this.
This is **mandatory** support for the version DTExchange **8.2.1**.
However this adapter version **should be used with 8.2.0 SDK** as well, please merge it instead of: https://github.com/googleads/googleads-mobile-ios-mediation/pull/407 and https://github.com/googleads/googleads-mobile-ios-mediation/pull/408

Please be noted this is our new official fork, the previous Fyber Engineering account is not relevant anymore.
@TomerFyber FYI