### PR TITLE
Added support for the arm64 simulator architecture in LiftoffMonetize…

### DIFF
--- a/adapters/LiftoffMonetize/BuildScript/Script_Framework.sh
+++ b/adapters/LiftoffMonetize/BuildScript/Script_Framework.sh
@@ -49,7 +49,7 @@ createFramework() {
 }
 
 createFramework "iphoneos" "arm64"
-createFramework "iphonesimulator" "x86_64"
+createFramework "iphonesimulator" "arm64 x86_64"
 
 # Create dynamic framework using the frameworks generated above.
 xcodebuild -create-xcframework \


### PR DESCRIPTION
… Adapter

This should make it possible to test on the simulator on Apple Silicon Macs.