### PR TITLE
Updating Vungle iOS Adapter v7.0.1.0. Adding watermark support

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
@@ -117,6 +117,9 @@
       initWithPlacementId:self.desiredPlacement
                      size:GADMAdapterVungleConvertGADAdSizeToBannerSize(_bannerSize)];
   _bannerAd.delegate = self;
+  VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
+  [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
+  [_bannerAd setWithExtras:extras];
   [_bannerAd load:_adConfiguration.bidResponse];
 }
 

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -101,6 +101,9 @@
 - (void)loadAd {
   _interstitialAd = [[VungleInterstitial alloc] initWithPlacementId:self.desiredPlacement];
   _interstitialAd.delegate = self;
+  VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
+  [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
+  [_interstitialAd setWithExtras:extras];
   [_interstitialAd load:_adConfiguration.bidResponse];
 }
 

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -102,6 +102,9 @@
 - (void)loadAd {
   _nativeAd = [[VungleNative alloc] initWithPlacementId:self.desiredPlacement];
   _nativeAd.delegate = self;
+  VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
+  [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
+  [_nativeAd setWithExtras:extras];
   VungleAdNetworkExtras *networkExtras = _adConfiguration.extras;
   switch (networkExtras.nativeAdOptionPosition) {
     case 1:

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -89,6 +89,9 @@
 - (void)loadRewardedAd {
   _rewardedAd = [[VungleRewarded alloc] initWithPlacementId:self.desiredPlacement];
   _rewardedAd.delegate = self;
+  VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
+  [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
+  [_rewardedAd setWithExtras:extras];
   [_rewardedAd load:_adConfiguration.bidResponse];
 }
 

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.0.0.0";
+static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.0.1.0";
 static NSString *const _Nonnull GADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull GADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull GADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";


### PR DESCRIPTION
Please verify the watermark functionality.

We inserted the iOS code from the Ads Identification Technology Guide, but also set the alpha value of the UIImage to be 0.03 because the guide stated that `The opacity of the overlay will not exceed 3%` and there's a `TODO` about verifying the alpha value in the sample code.
[Vungle -  Ads Identification Technology Guide.pdf](https://github.com/googleads/googleads-mobile-ios-mediation/files/11841264/Vungle.-.Ads.Identification.Technology.Guide.pdf)
