### PR TITLE
[Unity Ads 4.8.0] Adding usage of bannerDidShow callback to report impressions

### DIFF
--- a/adapters/Unity/UnityAdapter/AdNetworkAdapterProxy/GADMUnityBannerNetworkAdapterProxy.m
+++ b/adapters/Unity/UnityAdapter/AdNetworkAdapterProxy/GADMUnityBannerNetworkAdapterProxy.m
@@ -43,4 +43,7 @@
   [self.connector adapterWillLeaveApplication:self.adapter];
 }
 
+- (void)bannerViewDidShow:(UADSBannerView *)bannerView {
+}
+
 @end

--- a/adapters/Unity/UnityAdapter/MediationAdapterProxy/GADUnityBaseMediationAdapterProxy.m
+++ b/adapters/Unity/UnityAdapter/MediationAdapterProxy/GADUnityBaseMediationAdapterProxy.m
@@ -67,4 +67,8 @@
 - (void)bannerViewDidLeaveApplication:(UADSBannerView *)bannerView {
 }
 
+- (void)bannerViewDidShow:(UADSBannerView *)bannerView {
+  [self.eventDelegate reportImpression];
+}
+
 @end


### PR DESCRIPTION
### Description
In Unity Ads 4.8.0, we are adding a new bannerViewDidShow callback to our banner listener to more accurately report impressions.

### How
Added bannerViewDidShow to the delegate in GADMUnityBannerNetworkAdapterProxy
Added bannerViewDidShow to the delegate in GADUnityBaseMediationAdapterProxy and called reportAdImpression