### PR TITLE
[Liftoff Monetize] 7.2.0.0 - Update error objects to use the Liftoff errors where applicable

### DIFF
--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleBanner.m
@@ -62,10 +62,8 @@
     _adConfiguration = adConfiguration;
     _bannerSize = GADMAdapterVungleAdSizeForAdSize(adConfiguration.adSize);
 
-    VungleAdNetworkExtras *networkExtras = adConfiguration.extras;
     self.desiredPlacement =
-        [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings
-                                networkExtras:networkExtras];
+        [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings];
 
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
     __block GADMediationBannerLoadCompletionHandler origAdLoadHandler = [completionHandler copy];
@@ -96,13 +94,6 @@
     _adLoadCompletionHandler(nil, error);
     return;
   }
-
-  if (!self.desiredPlacement.length) {
-    NSError *error = GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription();
-    _adLoadCompletionHandler(nil, error);
-    return;
-  }
-
   if (![VungleAds isInitialized]) {
     NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
     [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
@@ -135,9 +126,7 @@
 }
 
 - (void)bannerAdDidFailToLoad:(nonnull VungleBanner *)banner withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  _adLoadCompletionHandler(nil, gadError);
+  _adLoadCompletionHandler(nil, error);
 }
 
 - (void)bannerAdWillPresent:(nonnull VungleBanner *)banner {
@@ -149,9 +138,7 @@
 }
 
 - (void)bannerAdDidFailToPresent:(nonnull VungleBanner *)banner withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorRenderBannerAd,
-                                                       error.code, error.localizedDescription);
-  [_delegate didFailToPresentWithError:gadError];
+  [_delegate didFailToPresentWithError:error];
 }
 
 - (void)bannerAdWillClose:(nonnull VungleBanner *)banner {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleInterstitial.m
@@ -50,8 +50,7 @@
   if (self) {
     _adConfiguration = adConfiguration;
     self.desiredPlacement =
-        [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings
-                                networkExtras:adConfiguration.extras];
+        [GADMAdapterVungleUtils findPlacement:adConfiguration.credentials.settings];
 
     __block atomic_flag adLoadHandlerCalled = ATOMIC_FLAG_INIT;
     __block GADMediationInterstitialLoadCompletionHandler origAdLoadHandler =
@@ -75,12 +74,6 @@
 }
 
 - (void)requestInterstitialAd {
-  if (!self.desiredPlacement.length) {
-    NSError *error = GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription();
-    _adLoadCompletionHandler(nil, error);
-    return;
-  }
-
   if (![VungleAds isInitialized]) {
     NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
     [GADMAdapterVungleRouter.sharedInstance initWithAppId:appID delegate:self];
@@ -117,9 +110,7 @@
 
 - (void)interstitialAdDidFailToLoad:(nonnull VungleInterstitial *)interstitial
                           withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  _adLoadCompletionHandler(nil, gadError);
+  _adLoadCompletionHandler(nil, error);
 }
 
 - (void)interstitialAdWillPresent:(nonnull VungleInterstitial *)interstitial {
@@ -132,9 +123,7 @@
 
 - (void)interstitialAdDidFailToPresent:(nonnull VungleInterstitial *)interstitial
                              withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  [_delegate didFailToPresentWithError:gadError];
+  [_delegate didFailToPresentWithError:error];
 }
 
 - (void)interstitialAdWillClose:(nonnull VungleInterstitial *)interstitial {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleNativeAd.m
@@ -82,14 +82,7 @@
 
 - (void)requestNativeAd {
   self.desiredPlacement =
-      [GADMAdapterVungleUtils findPlacement:_adConfiguration.credentials.settings
-                              networkExtras:_adConfiguration.extras];
-  if (!self.desiredPlacement) {
-    NSError *error = GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription();
-    _adLoadCompletionHandler(nil, error);
-    return;
-  }
-
+      [GADMAdapterVungleUtils findPlacement:_adConfiguration.credentials.settings];
   if (![VungleAds isInitialized]) {
     NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
     [[GADMAdapterVungleRouter sharedInstance] initWithAppId:appID delegate:self];
@@ -228,15 +221,11 @@
 }
 
 - (void)nativeAdDidFailToLoad:(nonnull VungleNative *)native withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  _adLoadCompletionHandler(nil, gadError);
+  _adLoadCompletionHandler(nil, error);
 }
 
 - (void)nativeAdDidFailToPresent:(nonnull VungleNative *)native withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  [_delegate didFailToPresentWithError:gadError];
+  [_delegate didFailToPresentWithError:error];
 }
 
 - (void)nativeAdDidClick:(nonnull VungleNative *)nativeAd {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -87,9 +87,9 @@
   [_rewardedAd setWithExtras:extras];
   if ([_adConfiguration extras] &&
       [[_adConfiguration extras] isKindOfClass:[VungleAdNetworkExtras class]]) {
-    VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)[_adConfiguration extras];
-    if (extras && extras.userId) {
-      [_rewardedAd setUserIdWithUserId:extras.userId];
+    VungleAdNetworkExtras *networkExtras = (VungleAdNetworkExtras *)[_adConfiguration extras];
+    if (networkExtras && networkExtras.userId) {
+      [_rewardedAd setUserIdWithUserId:networkExtras.userId];
     }
   }
   [_rewardedAd load:_adConfiguration.bidResponse];

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/Bidding/GADMediationVungleRewardedAd.m
@@ -85,13 +85,13 @@
   VungleAdsExtras *extras = [[VungleAdsExtras alloc] init];
   [extras setWithWatermark:[_adConfiguration.watermark base64EncodedStringWithOptions:0]];
   [_rewardedAd setWithExtras:extras];
-    if ([_adConfiguration extras] &&
-        [[_adConfiguration extras] isKindOfClass:[VungleAdNetworkExtras class]]) {
-      VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)[_adConfiguration extras];
-      if (extras && extras.userId) {
-        [_rewardedAd setUserIdWithUserId:extras.userId];
-      }
+  if ([_adConfiguration extras] &&
+      [[_adConfiguration extras] isKindOfClass:[VungleAdNetworkExtras class]]) {
+    VungleAdNetworkExtras *extras = (VungleAdNetworkExtras *)[_adConfiguration extras];
+    if (extras && extras.userId) {
+      [_rewardedAd setUserIdWithUserId:extras.userId];
     }
+  }
   [_rewardedAd load:_adConfiguration.bidResponse];
 }
 

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleBanner.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleBanner.m
@@ -73,26 +73,13 @@
     return;
   }
 
-  VungleAdNetworkExtras *networkExtras = [strongConnector networkExtras];
-  self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:[strongConnector credentials]
-                                                  networkExtras:networkExtras];
-  if (!self.desiredPlacement.length) {
-    NSError *error = GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription();
-    [strongConnector adapter:strongAdapter didFailAd:error];
-    return;
-  }
-
+  self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:[strongConnector credentials]];
   if ([VungleAds isInitialized]) {
     [self loadAd];
     return;
   }
 
   NSString *appID = [GADMAdapterVungleUtils findAppID:[strongConnector credentials]];
-  if (!appID) {
-    NSError *error = GADMAdapterVungleInvalidAppIdErrorWithCodeAndDescription();
-    [strongConnector adapter:strongAdapter didFailAd:error];
-    return;
-  }
   [GADMAdapterVungleRouter.sharedInstance initWithAppId:appID delegate:self];
 }
 
@@ -114,9 +101,7 @@
 }
 
 - (void)bannerAdDidFailToLoad:(nonnull VungleBanner *)banner withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  [_connector adapter:_adapter didFailAd:gadError];
+  [_connector adapter:_adapter didFailAd:error];
 }
 
 - (void)bannerAdWillPresent:(nonnull VungleBanner *)banner {
@@ -128,9 +113,7 @@
 }
 
 - (void)bannerAdDidFailToPresent:(nonnull VungleBanner *)banner withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorRenderBannerAd,
-                                                       error.code, error.localizedDescription);
-  [_connector adapter:_adapter didFailAd:gadError];
+  [_connector adapter:_adapter didFailAd:error];
 }
 
 - (void)bannerAdWillClose:(nonnull VungleBanner *)banner {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleConstants.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.1.0.0";
+static NSString *const _Nonnull GADMAdapterVungleVersion = @"7.2.0.0";
 static NSString *const _Nonnull GADMAdapterVungleApplicationID = @"application_id";
 static NSString *const _Nonnull GADMAdapterVunglePlacementID = @"placementID";
 static NSString *const _Nonnull GADMAdapterVungleErrorDomain = @"com.google.mediation.vungle";

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleInterstitial.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleInterstitial.m
@@ -76,25 +76,13 @@
   if (strongConnector.childDirectedTreatment) {
     [VunglePrivacySettings setCOPPAStatus:[strongConnector.childDirectedTreatment boolValue]];
   }
-  self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:[strongConnector credentials]
-                                                  networkExtras:[strongConnector networkExtras]];
-  if (!self.desiredPlacement.length) {
-    [strongConnector adapter:self
-                   didFailAd:GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription()];
-    return;
-  }
-
+  self.desiredPlacement = [GADMAdapterVungleUtils findPlacement:[strongConnector credentials]];
   if ([VungleAds isInitialized]) {
     [self loadAd];
     return;
   }
 
   NSString *appID = [GADMAdapterVungleUtils findAppID:[strongConnector credentials]];
-  if (!appID) {
-    NSError *error = GADMAdapterVungleInvalidAppIdErrorWithCodeAndDescription();
-    [strongConnector adapter:self didFailAd:error];
-    return;
-  }
   [GADMAdapterVungleRouter.sharedInstance initWithAppId:appID delegate:self];
 }
 
@@ -128,9 +116,7 @@
 
 - (void)interstitialAdDidFailToLoad:(nonnull VungleInterstitial *)interstitial
                           withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  [_connector adapter:self didFailAd:gadError];
+  [_connector adapter:self didFailAd:error];
 }
 
 - (void)interstitialAdWillPresent:(nonnull VungleInterstitial *)interstitial {
@@ -143,9 +129,7 @@
 
 - (void)interstitialAdDidFailToPresent:(nonnull VungleInterstitial *)interstitial
                              withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  [_connector adapter:self didFailAd:gadError];
+  [_connector adapter:self didFailAd:error];
 }
 
 - (void)interstitialAdWillClose:(nonnull VungleInterstitial *)interstitial {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRewardBasedVideoAd.m
@@ -82,14 +82,7 @@
 
 - (void)requestRewardedAd {
   self.desiredPlacement =
-      [GADMAdapterVungleUtils findPlacement:_adConfiguration.credentials.settings
-                              networkExtras:_adConfiguration.extras];
-  if (!self.desiredPlacement.length) {
-    NSError *error = GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription();
-    _adLoadCompletionHandler(nil, error);
-    return;
-  }
-
+      [GADMAdapterVungleUtils findPlacement:_adConfiguration.credentials.settings];
   if (![VungleAds isInitialized]) {
     NSString *appID = [GADMAdapterVungleUtils findAppID:_adConfiguration.credentials.settings];
     [GADMAdapterVungleRouter.sharedInstance initWithAppId:appID delegate:self];
@@ -126,9 +119,7 @@
 
 - (void)rewardedAdDidFailToLoad:(nonnull VungleRewarded *)rewarded
                       withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  _adLoadCompletionHandler(nil, gadError);
+  _adLoadCompletionHandler(nil, error);
 }
 
 - (void)rewardedAdWillPresent:(nonnull VungleRewarded *)rewarded {
@@ -141,9 +132,7 @@
 
 - (void)rewardedAdDidFailToPresent:(nonnull VungleRewarded *)rewarded
                          withError:(nonnull NSError *)error {
-  NSError *gadError = GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorAdNotPlayable,
-                                                       error.code, error.localizedDescription);
-  [_delegate didFailToPresentWithError:gadError];
+  [_delegate didFailToPresentWithError:error];
 }
 
 - (void)rewardedAdWillClose:(nonnull VungleRewarded *)rewarded {

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRouter.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleRouter.m
@@ -44,31 +44,18 @@ static NSString *const _Nonnull GADMAdapterVungleNullPubRequestID = @"null";
                                                                             withString:@"_"];
     [VungleAds setIntegrationName:@"admob" version:version];
   });
-
   if ([VungleAds isInitialized]) {
     [delegate initialized:YES error:nil];
     return;
   }
-
-  if (_isInitializing) {
-    @synchronized(_delegates) {
-      GADMAdapterVungleMutableSetAddObject(_delegates, delegate);
-    }
-    return;
+  @synchronized(_delegates) {
+    GADMAdapterVungleMutableSetAddObject(_delegates, delegate);
   }
-
-  if (!appId) {
-    NSError *error = GADMAdapterVungleInvalidAppIdErrorWithCodeAndDescription();
-    [delegate initialized:NO error:error];
+  if (_isInitializing) {
     return;
   }
 
   _isInitializing = YES;
-
-  @synchronized(_delegates) {
-    GADMAdapterVungleMutableSetAddObject(_delegates, delegate);
-  }
-
   [VungleAds initWithAppId:appId
                 completion:^(NSError *_Nullable error) {
                   self->_isInitializing = NO;

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.h
@@ -22,22 +22,6 @@
 NSError *_Nonnull GADMAdapterVungleErrorWithCodeAndDescription(GADMAdapterVungleErrorCode code,
                                                                NSString *_Nonnull description);
 
-/// Returns a NSError converted from the error object from Vungle SDK into the AdMob
-/// error format The localized description will contain the Liftoff Monetize error code and the
-/// description from the Vungle SDK.
-NSError *_Nonnull GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorCode code,
-                                                   NSInteger vungleCode,
-                                                   NSString *_Nonnull description);
-
-/// Returns a NSError with code |code| and with NSLocalizedDescriptionKey and
-/// NSLocalizedFailureReasonErrorKey values set to |description|, specifically for invalid placement
-/// id.
-NSError *_Nonnull GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription(void);
-
-/// Returns a NSError with code |code| and with NSLocalizedDescriptionKey and
-/// NSLocalizedFailureReasonErrorKey values set to |description|, specifically for invalid app id.
-NSError *_Nonnull GADMAdapterVungleInvalidAppIdErrorWithCodeAndDescription(void);
-
 /// Returns a GADAdSize object that is valid for Vungle SDK.
 GADAdSize GADMAdapterVungleAdSizeForAdSize(GADAdSize adSize);
 
@@ -49,8 +33,7 @@ void GADMAdapterVungleMutableSetAddObject(NSMutableSet *_Nullable set, NSObject 
 
 @interface GADMAdapterVungleUtils : NSObject
 
-+ (nullable NSString *)findAppID:(nullable NSDictionary *)serverParameters;
-+ (nullable NSString *)findPlacement:(nullable NSDictionary *)serverParameters
-                       networkExtras:(nullable VungleAdNetworkExtras *)networkExtras;
++ (nonnull NSString *)findAppID:(nullable NSDictionary *)serverParameters;
++ (nonnull NSString *)findPlacement:(nullable NSDictionary *)serverParameters;
 
 @end

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMAdapterVungleUtils.m
@@ -25,29 +25,6 @@ NSError *_Nonnull GADMAdapterVungleErrorWithCodeAndDescription(GADMAdapterVungle
   return error;
 }
 
-NSError *_Nonnull GADMAdapterVungleErrorToGADError(GADMAdapterVungleErrorCode code,
-                                                   NSInteger vungleCode,
-                                                   NSString *_Nonnull description) {
-  NSString *formattedDescription =
-      [NSString stringWithFormat:@"Vungle SDK returned an error with code: %ld, description: '%@'",
-                                 (long)vungleCode, description];
-  return GADMAdapterVungleErrorWithCodeAndDescription(code, formattedDescription);
-}
-
-NSError *_Nonnull GADMAdapterVungleInvalidPlacementErrorWithCodeAndDescription() {
-  GADMAdapterVungleErrorCode code = GADMAdapterVungleErrorInvalidServerParameters;
-  NSString *description =
-      @"Missing or invalid Placement ID configured for this ad source instance in the AdMob or "
-      @"Ad Manager UI.";
-  return GADMAdapterVungleErrorWithCodeAndDescription(code, description);
-}
-
-NSError *_Nonnull GADMAdapterVungleInvalidAppIdErrorWithCodeAndDescription() {
-  GADMAdapterVungleErrorCode code = GADMAdapterVungleErrorInvalidServerParameters;
-  NSString *description = @"Liftoff Monetize app ID not specified.";
-  return GADMAdapterVungleErrorWithCodeAndDescription(code, description);
-}
-
 const CGSize kVNGBannerShortSize = {300, 50};
 GADAdSize GADMAdapterVungleAdSizeForAdSize(GADAdSize adSize) {
   // It has to match for MREC, otherwise it would be a banner with flexible size
@@ -95,29 +72,19 @@ BannerSize GADMAdapterVungleConvertGADAdSizeToBannerSize(GADAdSize adSize) {
 
 @implementation GADMAdapterVungleUtils
 
-+ (nullable NSString *)findAppID:(nullable NSDictionary *)serverParameters {
++ (nonnull NSString *)findAppID:(nullable NSDictionary *)serverParameters {
   NSString *appId = serverParameters[GADMAdapterVungleApplicationID];
   if (!appId) {
     NSString *const message = @"Liftoff Monetize app ID should be specified!";
     NSLog(message);
-    return nil;
+    return @"";
   }
   return appId;
 }
 
-+ (nullable NSString *)findPlacement:(nullable NSDictionary *)serverParameters
-                       networkExtras:(nullable VungleAdNetworkExtras *)networkExtras {
-  NSString *ret = serverParameters[GADMAdapterVunglePlacementID];
-  if (networkExtras && networkExtras.playingPlacement) {
-    if (ret) {
-      NSLog(@"'placementID' had a value in both serverParameters and networkExtras. "
-            @"Used one from serverParameters.");
-    } else {
-      ret = networkExtras.playingPlacement;
-    }
-  }
-
-  return ret;
++ (nonnull NSString *)findPlacement:(nullable NSDictionary *)serverParameters {
+  NSString *placementId = serverParameters[GADMAdapterVunglePlacementID];
+  return placementId ? placementId : @"";
 }
 
 #pragma mark - Safe Collection utility methods.

--- a/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationAdapterVungle.h
+++ b/adapters/LiftoffMonetize/LiftoffMonetizeAdapter/GADMediationAdapterVungle.h
@@ -18,17 +18,8 @@
 typedef NS_ENUM(NSInteger, GADMAdapterVungleErrorCode) {
   /// Missing server parameters.
   GADMAdapterVungleErrorInvalidServerParameters = 101,
-  /// An ad is already loaded for this network configuration. Vungle SDK cannot load
-  /// a second ad for the same placement ID.
-  GADMAdapterVungleErrorAdAlreadyLoaded = 102,
   /// Banner Size Mismatch.
-  GADMAdapterVungleErrorBannerSizeMismatch = 103,
-  /// Vungle SDK could not render the banner ad.
-  GADMAdapterVungleErrorRenderBannerAd = 104,
-  /// Vungle SDK only supports loading 1 banner ad at a time, regardless of placement ID.
-  GADMAdapterVungleErrorMultipleBanners = 105,
-  /// Vungle SDK sent a callback saying the ad is not playable.
-  GADMAdapterVungleErrorAdNotPlayable = 106
+  GADMAdapterVungleErrorBannerSizeMismatch = 103
 };
 
 @interface GADMediationAdapterVungle : NSObject <GADRTBAdapter>


### PR DESCRIPTION
The Liftoff error codes has been added to public documentation.

Please update Google's public documentation for Liftoff SDK to refer to this page for the error codes:
https://support.vungle.com/hc/en-us/articles/15661036969627

Thanks.