### PR TITLE
DTExchange SDK: removed keywords support

### DIFF
--- a/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
+++ b/adapters/DTExchange/DTExchangeAdapter/GADMAdapterFyberUtils.m
@@ -62,10 +62,6 @@ IAAdRequest *_Nonnull GADMAdapterFyberBuildRequestWithSpotIDAndAdConfiguration(
   IASDKCore.sharedInstance.userData = extras.userData;
   IASDKCore.sharedInstance.muteAudio = extras.muteAudio;
 
-  if (extras.keywords) {
-    IASDKCore.sharedInstance.keywords = extras.keywords;
-  }
-
   IAAdRequest *request = [IAAdRequest build:^(id<IAAdRequestBuilder> _Nonnull builder) {
     builder.useSecureConnections = NO;
     builder.spotID = spotID;


### PR DESCRIPTION
Hi! Please merge this PR into nearest Google Adapter for DTExchange SDK, since we are gonna deprecate this API, starting from future version 8.3.3.
Thanks in advance.