### PR TITLE
#AppLovinAdapter Move didRewardUser to the correct AppLovin callback.

### DIFF
--- a/AdapterUnitTests/AppLovinAdapterTests/AUTAppLovinRewardedAdTests.m
+++ b/AdapterUnitTests/AppLovinAdapterTests/AUTAppLovinRewardedAdTests.m
@@ -216,6 +216,10 @@
   AUTKMediationRewardedAdEventDelegate *delegate = [self loadAd];
   [self->_adLoader videoPlaybackEndedInAd:OCMOCK_ANY atPlaybackPercent:@98.0f fullyWatched:YES];
   [self->_adLoader ad:OCMOCK_ANY wasHiddenIn:OCMOCK_ANY];
+  NSDictionary<NSString *, NSString *> *successResponse =
+      @{@"currency" : @"reward", @"amount" : @"20"};
+
+  [self->_adLoader rewardValidationRequestForAd:OCMOCK_ANY didSucceedWithResponse:successResponse];
   XCTAssertTrue(delegate.didRewardUserInvokeCount == 1);
 }
 
@@ -231,9 +235,6 @@
   // but verify invoking them does not crash the running app.
   [self loadAd];
 
-  NSDictionary<NSString *, NSString *> *successResponse =
-      @{@"currency" : @"reward", @"amount" : @"20"};
-  [self->_adLoader rewardValidationRequestForAd:OCMOCK_ANY didSucceedWithResponse:successResponse];
   [self->_adLoader rewardValidationRequestForAd:OCMOCK_ANY didFailWithError:9001];
 
   NSDictionary<NSString *, NSString *> *quotaResponse = @{@"response" : @"unknown"};

--- a/adapters/AppLovin/AppLovinAdapter/Bidding/GADMAppLovinRewardedDelegate.m
+++ b/adapters/AppLovin/AppLovinAdapter/Bidding/GADMAppLovinRewardedDelegate.m
@@ -87,9 +87,6 @@
   [GADMAdapterAppLovinUtils log:@"Rewarded ad dismissed"];
   GADMAdapterAppLovinRewardedRenderer *parentRenderer = _parentRenderer;
   id<GADMediationRewardedAdEventDelegate> delegate = parentRenderer.delegate;
-  if (_fullyWatched) {
-    [delegate didRewardUser];
-  }
   [GADMAdapterAppLovinMediationManager.sharedInstance
       removeRewardedZoneIdentifier:parentRenderer.zoneIdentifier];
 
@@ -138,6 +135,8 @@
 
 - (void)rewardValidationRequestForAd:(nonnull ALAd *)ad
               didSucceedWithResponse:(nonnull NSDictionary *)response {
+  [_parentRenderer.delegate didRewardUser];
+
   NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:response[@"amount"]];
   NSString *currency = response[@"currency"];
 

--- a/adapters/AppLovin/CHANGELOG.md
+++ b/adapters/AppLovin/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## AppLovin iOS Mediation Adapter Changelog
 
+#### Next version
+- Moved didRewardUser call from within ad:wasHiddenIn callback to the more appropriate rewardValidationRequestForAd:didSucceedWithResponse callback.
+
 #### [Version 13.0.0.0](https://dl.google.com/googleadmobadssdk/mediation/ios/applovin/AppLovinAdapter-13.0.0.0.zip)
 - Verified compatibility with AppLovin SDK 13.0.0.
 


### PR DESCRIPTION
#AppLovinAdapter Move didRewardUser to the correct AppLovin callback.

Calling didRewardUser from within ad:wasHiddenIn callback was making the publisher be notified of reward before the ad actually finished playing.
