### PR TITLE
- Replaced the deprecated AppLovin SDK's bid token collection API with its new one.

### DIFF
--- a/adapters/AppLovin/AppLovinAdapter/GADMediationAdapterAppLovin.m
+++ b/adapters/AppLovin/AppLovinAdapter/GADMediationAdapterAppLovin.m
@@ -130,16 +130,24 @@
     completionHandler(nil, error);
     return;
   }
-  NSString *signal = ALSdk.shared.adService.bidToken;
 
-  if (signal.length > 0) {
-    [GADMAdapterAppLovinUtils log:@"Generated bid token %@.", signal];
-    completionHandler(signal, nil);
-  } else {
-    NSError *error = GADMAdapterAppLovinErrorWithCodeAndDescription(
-        GADMAdapterAppLovinErrorEmptyBidToken, @"Bid token is empty.");
-    completionHandler(nil, error);
-  }
+  [ALSdk.shared.adService collectBidTokenWithCompletion:^(NSString *_Nullable bidToken,
+                                                          NSString *_Nullable errorMessage) {
+    if (errorMessage) {
+      NSError *error = GADMAdapterAppLovinErrorWithCodeAndDescription(
+          GADMAdapterAppLovinErrorFailedToReturnBidToken, errorMessage);
+      completionHandler(nil, error);
+      return;
+    }
+    if (bidToken.length > 0) {
+      [GADMAdapterAppLovinUtils log:@"Generated bid token %@.", bidToken];
+      completionHandler(bidToken, nil);
+    } else {
+      NSError *error = GADMAdapterAppLovinErrorWithCodeAndDescription(
+          GADMAdapterAppLovinErrorEmptyBidToken, @"Bid token is empty.");
+      completionHandler(nil, error);
+    }
+  }];
 }
 
 #pragma mark - GADMediationAdapter load Ad

--- a/adapters/AppLovin/CHANGELOG.md
+++ b/adapters/AppLovin/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Next Version
 - Replaced the deprecated AppLovin SDK's initialization APIs with its new APIs.
 - Prevented multiple initializations of AppLovin SDK when multiple AppLovin SDK keys are provided.
+- Replaced the deprecated AppLovin SDK's bid token collection API with its new one.
 
 #### [Version 13.0.1.0](https://dl.google.com/googleadmobadssdk/mediation/ios/applovin/AppLovinAdapter-13.0.1.0.zip)
 - Verified compatibility with AppLovin SDK 13.0.1.

--- a/adapters/AppLovin/Public/Headers/GADMediationAdapterAppLovin.h
+++ b/adapters/AppLovin/Public/Headers/GADMediationAdapterAppLovin.h
@@ -49,8 +49,10 @@ typedef NS_ENUM(NSInteger, GADMAdapterAppLovinErrorCode) {
   GADMAdapterAppLovinErrorChildUser = 112,
 
   /// AppLovin SDK shared instance hasn't been initialized.
-  GADMAdapterAppLovinErrorAppLovinSDKNotInitialized = 113
+  GADMAdapterAppLovinErrorAppLovinSDKNotInitialized = 113,
 
+  /// AppLovin SDK fails to return bid token with an error message.
+  GADMAdapterAppLovinErrorFailedToReturnBidToken = 114
 };
 
 @interface GADMediationAdapterAppLovin : NSObject <GADRTBAdapter>


### PR DESCRIPTION
- Replaced the deprecated AppLovin SDK's bid token collection API with its new one.
- Replaced the deprecated AppLovin SDK's initialization APIs with its new APIs.
- Prevented multiple initializations of AppLovin SDK when multiple AppLovin SDK keys are provided.
