### PR TITLE
Moloco Native ad support in adapter.

### DIFF
--- a/AdapterUnitTests/AdapterUnitTests.xcodeproj/project.pbxproj
+++ b/AdapterUnitTests/AdapterUnitTests.xcodeproj/project.pbxproj
@@ -163,6 +163,9 @@
 		ADFAAF042A33C35800D92129 /* AUTLineAdapterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = ADFAAF032A33C35800D92129 /* AUTLineAdapterTest.m */; };
 		ADFAAF0E2A33F1F600D92129 /* AdapterUnitTestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD6FA0352A16BF4A007335D2 /* AdapterUnitTestKit.framework */; };
 		ADFAAF142A33F36500D92129 /* AUTKConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = ADFAAF132A33F36500D92129 /* AUTKConstants.m */; };
+		F090AA192D6563F4003DB8CC /* FakeMolocoNativeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090AA182D6563F4003DB8CC /* FakeMolocoNativeFactory.swift */; };
+		F090AA1A2D6563F4003DB8CC /* FakeMolocoNativeAd.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090AA172D6563F4003DB8CC /* FakeMolocoNativeAd.swift */; };
+		F090AA1C2D656413003DB8CC /* MolocoNativeAdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090AA1B2D656413003DB8CC /* MolocoNativeAdTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -830,6 +833,9 @@
 		ADF3B9B82AF3015E00B665AB /* AUTAppLovinRewardedAdTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AUTAppLovinRewardedAdTests.m; sourceTree = "<group>"; };
 		ADFAAF032A33C35800D92129 /* AUTLineAdapterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AUTLineAdapterTest.m; sourceTree = "<group>"; };
 		ADFAAF132A33F36500D92129 /* AUTKConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AUTKConstants.m; sourceTree = "<group>"; };
+		F090AA172D6563F4003DB8CC /* FakeMolocoNativeAd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMolocoNativeAd.swift; sourceTree = "<group>"; };
+		F090AA182D6563F4003DB8CC /* FakeMolocoNativeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMolocoNativeFactory.swift; sourceTree = "<group>"; };
+		F090AA1B2D656413003DB8CC /* MolocoNativeAdTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolocoNativeAdTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1034,6 +1040,8 @@
 				85A57D722CA4B663009FC260 /* FakeMolocoBannerFactory.swift */,
 				70608B4F2C51C64300896E93 /* FakeMolocoInterstitial.swift */,
 				70608B512C51C65900896E93 /* FakeMolocoInterstitialFactory.swift */,
+				F090AA172D6563F4003DB8CC /* FakeMolocoNativeAd.swift */,
+				F090AA182D6563F4003DB8CC /* FakeMolocoNativeFactory.swift */,
 				856602EC2C642DE70068D786 /* FakeMolocoRewarded.swift */,
 				8526681D2C755D15000BBD3A /* FakeMolocoRewardedFactory.swift */,
 				70A1FA3A2CC371C200BC54D0 /* FakeMolocoBidTokenGetter.swift */,
@@ -1061,6 +1069,7 @@
 				85A57D6E2CA4B640009FC260 /* MolocoBannerAdTest.swift */,
 				70E380AF2C46FB8E004CCB92 /* MolocoMediationAdapterTest.swift */,
 				706083C42C47CAAA00896E93 /* MolocoInterstitialAdTest.swift */,
+				F090AA1B2D656413003DB8CC /* MolocoNativeAdTest.swift */,
 				8595C0C32C59A82B00B46FD2 /* MolocoRewardedAdTest.swift */,
 			);
 			path = MolocoAdapterTests;
@@ -2384,8 +2393,11 @@
 				70E380B02C46FB8E004CCB92 /* MolocoMediationAdapterTest.swift in Sources */,
 				70387DD42D08B7D4000C09EE /* FakeMolocoAgeRestrictedSetter.swift in Sources */,
 				70608B502C51C64300896E93 /* FakeMolocoInterstitial.swift in Sources */,
+				F090AA1C2D656413003DB8CC /* MolocoNativeAdTest.swift in Sources */,
 				85A57D732CA4B663009FC260 /* FakeMolocoBannerFactory.swift in Sources */,
 				703877332CF54DC2000C09EE /* FakeMolocoSdkVersionProvider.swift in Sources */,
+				F090AA192D6563F4003DB8CC /* FakeMolocoNativeFactory.swift in Sources */,
+				F090AA1A2D6563F4003DB8CC /* FakeMolocoNativeAd.swift in Sources */,
 				8526681E2C755D15000BBD3A /* FakeMolocoRewardedFactory.swift in Sources */,
 				70608B522C51C65900896E93 /* FakeMolocoInterstitialFactory.swift in Sources */,
 				ADAB37C12D23444400D407AB /* MolocoTestUtils.swift in Sources */,

--- a/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeAd.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeAd.swift
@@ -1,0 +1,104 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleMobileAds
+import MolocoSDK
+
+/// A fake implementation of MolocoNativeAd.
+final class FakeMolocoNativeAd {
+
+  /// The load error that occured.
+  let loadError: Error?
+
+  /// The show error that occured.
+  let showError: Error?
+
+  /// Var to capture the bid response that was used to load the ad on Moloco SDK. Used for
+  /// assertion. It is initlialized to a value that is never asserted for.
+  var bidResponseUsedToLoadMolocoAd: String = "nil"
+
+  // MolocoSDK.MolocoNativeAd properties.
+  var nativeDelegate: (any MolocoSDK.MolocoNativeAdDelegate)?
+  var isReady: Bool
+  var nativeAssets: MolocoNativeAdAssests? = nil
+
+  /// If loadError is nil, this fake mimics load success. If loadError is not nil, this fake mimics
+  /// load failure.
+  init(
+    nativeDelegate: any MolocoSDK.MolocoNativeAdDelegate, loadError: Error?,
+    isReadyToBeShown: Bool = true, showError: Error?
+  ) {
+    self.nativeDelegate = nativeDelegate
+    self.isReady = isReadyToBeShown
+    self.loadError = loadError
+    self.showError = showError
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+}
+
+// MARK: - MolocoSDK.MolocoNativeAd
+
+extension FakeMolocoNativeAd: MolocoSDK.MolocoNativeAd {
+  var adView: UIView {
+    UIView()
+  }
+  
+  var delegate: (any MolocoSDK.MolocoNativeAdDelegate)? {
+    get {
+      nativeDelegate
+    }
+    set(newValue) {
+      nativeDelegate = newValue
+    }
+  }
+  
+  var assets: (any MolocoSDK.MolocoNativeAdAssests)? {
+    nativeAssets
+  }
+  
+  var type: MolocoSDK.AdNativeType {
+    .unknownType
+  }
+  
+  func handleClick() {
+    delegate?.didHandleClick?(ad: self)
+  }
+  
+  func handleImpression() {
+    delegate?.didHandleImpression?(ad: self)
+  }
+
+  func show(from viewController: UIViewController, muted: Bool) {
+    // No-op.
+  }
+
+  func load(bidResponse: String) {
+    bidResponseUsedToLoadMolocoAd = bidResponse
+    guard let loadError else {
+      nativeDelegate?.didLoad(ad: self)
+      return
+    }
+    nativeDelegate?.failToLoad(ad: self, with: loadError)
+  }
+
+  func destroy() {
+    // No-op.
+  }
+
+}

--- a/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeFactory.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeFactory.swift
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import MolocoAdapter
+import MolocoSDK
+
+/// A fake implementation of MolocoNativeFactory that creates a FakeMolocoNative.
+final class FakeMolocoNativeFactory {
+
+  let loadError: Error?
+
+  let isReadyToBeShown: Bool
+
+  let showError: Error?
+
+  /// Var to capture the ad unit ID that was used to create the Moloco  ad object.
+  /// Used for assertion. It is initlialized to a value that is never asserted for.
+  var adUnitIDUsedToCreateMolocoAd: String = ""
+
+  var fakeMolocoNative: FakeMolocoNativeAd?
+
+  /// The parameters passed here are used to create FakeMolocoNative. See FakeMolocoNative for
+  /// how these parameters are used.
+  init(
+    loadError: Error?, isReadyToBeShown: Bool = true, showError: Error? = nil
+  ) {
+    self.loadError = loadError
+    self.isReadyToBeShown = isReadyToBeShown
+    self.showError = showError
+  }
+
+}
+
+// MARK: - MolocoNativeFactory
+
+extension FakeMolocoNativeFactory: MolocoNativeFactory {
+  func createNativeAd(for adUnit: String, delegate: any MolocoSDK.MolocoNativeAdDelegate) -> (any MolocoSDK.MolocoNativeAd)? {
+    adUnitIDUsedToCreateMolocoAd = adUnit
+    fakeMolocoNative = FakeMolocoNativeAd(
+      nativeDelegate: delegate, loadError: loadError, isReadyToBeShown: isReadyToBeShown,
+      showError: showError)
+    return fakeMolocoNative
+  }
+
+}

--- a/AdapterUnitTests/MolocoAdapterTests/MolocoNativeAdTest.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/MolocoNativeAdTest.swift
@@ -1,0 +1,105 @@
+import AdapterUnitTestKit
+import MolocoSDK
+import XCTest
+
+@testable import MolocoAdapter
+
+final class MolocoNativeAdTest: XCTestCase {
+
+  /// An ad unit ID used in testing.
+  static let testAdUnitID = "12345"
+  /// A bid response received by the adapter to load the ad.
+  static let testBidResponse = "bid_response"
+
+  func testNativeLoadSuccess() {
+    let molocoNativeFactory = FakeMolocoNativeFactory(loadError: nil)
+    let adapter = MolocoMediationAdapter(molocoNativeFactory: molocoNativeFactory)
+    let mediationAdConfig = AUTKMediationNativeAdConfiguration()
+    let credentials = AUTKMediationCredentials()
+    credentials.settings = [MolocoConstants.adUnitIdKey: Self.testAdUnitID]
+    mediationAdConfig.credentials = credentials
+    mediationAdConfig.bidResponse = Self.testBidResponse
+
+    AUTKWaitAndAssertLoadNativeAd(adapter, mediationAdConfig)
+    XCTAssertEqual(molocoNativeFactory.adUnitIDUsedToCreateMolocoAd, Self.testAdUnitID)
+    XCTAssertEqual(
+      molocoNativeFactory.fakeMolocoNative?.bidResponseUsedToLoadMolocoAd, Self.testBidResponse
+    )
+  }
+
+  func testNativeLoadFailure_ifBidResponseIsMissing() {
+    let molocoNativeFactory = FakeMolocoNativeFactory(loadError: nil)
+    let adapter = MolocoMediationAdapter(molocoNativeFactory: molocoNativeFactory)
+    let mediationAdConfig = AUTKMediationNativeAdConfiguration()
+    let credentials = AUTKMediationCredentials()
+    credentials.settings = [MolocoConstants.adUnitIdKey: Self.testAdUnitID]
+    mediationAdConfig.credentials = credentials
+
+    let expectedError = NSError(
+      domain: MolocoConstants.adapterErrorDomain,
+      code: MolocoAdapterErrorCode.nilBidResponse.rawValue)
+    AUTKWaitAndAssertLoadNativeAdFailure(adapter, mediationAdConfig, expectedError)
+  }
+
+  func testNativeLoad_loadsWithTestAdUnitForTestRequest() {
+    let molocoNativeFactory = FakeMolocoNativeFactory(loadError: nil)
+    let adapter = MolocoMediationAdapter(molocoNativeFactory: molocoNativeFactory)
+    let mediationAdConfig = AUTKMediationNativeAdConfiguration()
+    let credentials = AUTKMediationCredentials()
+    credentials.settings = [MolocoConstants.adUnitIdKey: Self.testAdUnitID]
+    mediationAdConfig.credentials = credentials
+    mediationAdConfig.isTestRequest = true
+
+    let expectedError = NSError(
+      domain: MolocoConstants.adapterErrorDomain,
+      code: MolocoAdapterErrorCode.nilBidResponse.rawValue)
+    AUTKWaitAndAssertLoadNativeAdFailure(adapter, mediationAdConfig, expectedError)
+  }
+
+  func testNativeLoadFailure_ifAdUnitIdIsMissing() {
+    let molocoNativeFactory = FakeMolocoNativeFactory(loadError: nil)
+    let adapter = MolocoMediationAdapter(molocoNativeFactory: molocoNativeFactory)
+    let mediationAdConfig = AUTKMediationNativeAdConfiguration()
+    let credentials = AUTKMediationCredentials()
+    mediationAdConfig.credentials = credentials
+    mediationAdConfig.bidResponse = Self.testBidResponse
+
+    let expectedError = NSError(
+      domain: MolocoConstants.adapterErrorDomain,
+      code: MolocoAdapterErrorCode.invalidAdUnitId.rawValue)
+    AUTKWaitAndAssertLoadNativeAdFailure(adapter, mediationAdConfig, expectedError)
+  }
+
+  func testNativeLoadFailure_ifMolocoFailsToLoad() {
+    let loadError = NSError(domain: "moloco_sdk_domain", code: 1002)
+    let adapter = MolocoMediationAdapter(
+      molocoNativeFactory: FakeMolocoNativeFactory(loadError: loadError))
+    let mediationAdConfig = AUTKMediationNativeAdConfiguration()
+    let credentials = AUTKMediationCredentials()
+    credentials.settings = [MolocoConstants.adUnitIdKey: Self.testAdUnitID]
+    mediationAdConfig.credentials = credentials
+    mediationAdConfig.bidResponse = Self.testBidResponse
+
+    AUTKWaitAndAssertLoadNativeAdFailure(adapter, mediationAdConfig, loadError)
+  }
+
+  func testNativeAdCorrectlyTriggersImpressionAndClick() {
+    let molocoNativeFactory = FakeMolocoNativeFactory(loadError: nil)
+    let adapter = MolocoMediationAdapter(molocoNativeFactory: molocoNativeFactory)
+    let mediationAdConfig = AUTKMediationNativeAdConfiguration()
+    let credentials = AUTKMediationCredentials()
+    credentials.settings = [MolocoConstants.adUnitIdKey: Self.testAdUnitID]
+    mediationAdConfig.credentials = credentials
+    mediationAdConfig.bidResponse = Self.testBidResponse
+    let adEventDelegate = AUTKWaitAndAssertLoadNativeAd(adapter, mediationAdConfig)
+    MolocoTestUtils.flushMainThread(self)
+    XCTAssertNotNil(adEventDelegate)
+    adEventDelegate.nativeAd?.didRecordImpression?()
+    adEventDelegate.nativeAd?.didRecordClickOnAsset?(withName: .bodyAsset, view: UIView(), viewController: UIViewController())
+    
+    XCTAssertNil(adEventDelegate.didFailToPresentError)
+    XCTAssertEqual(adEventDelegate.reportImpressionInvokeCount, 1)
+    XCTAssertEqual(adEventDelegate.reportClickInvokeCount, 1)
+  }
+
+}

--- a/AdapterUnitTests/MolocoAdapterTests/MolocoNativeAdTest.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/MolocoNativeAdTest.swift
@@ -95,7 +95,7 @@ final class MolocoNativeAdTest: XCTestCase {
     MolocoTestUtils.flushMainThread(self)
     XCTAssertNotNil(adEventDelegate)
     adEventDelegate.nativeAd?.didRecordImpression?()
-    adEventDelegate.nativeAd?.didRecordClickOnAsset?(withName: .bodyAsset, view: UIView(), viewController: UIViewController())
+    adEventDelegate.nativeAd?.didRecordClickOnAsset?(with: .bodyAsset, view: UIView(), viewController: UIViewController())
     
     XCTAssertNil(adEventDelegate.didFailToPresentError)
     XCTAssertEqual(adEventDelegate.reportImpressionInvokeCount, 1)

--- a/AdapterUnitTests/Podfile
+++ b/AdapterUnitTests/Podfile
@@ -14,7 +14,7 @@ platform :ios, '16.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-adapter_targets = ENV['ADAPTER_TARGETS']&.split(',') || []
+adapter_targets = ENV['ADAPTER_TARGETS']&.split(',') || ['MolocoAdapter']
 
 abstract_target 'Default' do
 

--- a/adapters/Moloco/MolocoAdapter.xcodeproj/project.pbxproj
+++ b/adapters/Moloco/MolocoAdapter.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		ADFA84C22C17704300A501AB /* InterstitialAdLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFA84AA2C17704300A501AB /* InterstitialAdLoader.swift */; };
 		ADFA84C32C17704300A501AB /* NativeAdLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFA84AB2C17704300A501AB /* NativeAdLoader.swift */; };
 		ADFA84C42C17704300A501AB /* RewardedAdLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFA84AC2C17704300A501AB /* RewardedAdLoader.swift */; };
+		F04223732D494E59005D2513 /* MolocoNativeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04223722D494E4A005D2513 /* MolocoNativeFactory.swift */; };
+		F04223742D494E59005D2513 /* MolocoNativeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04223722D494E4A005D2513 /* MolocoNativeFactory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -115,6 +117,7 @@
 		ADFA84B82C17704300A501AB /* Script_Validate.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Script_Validate.sh; sourceTree = "<group>"; };
 		ADFA84BC2C17704300A501AB /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		ADFA84D42C17738E00A501AB /* MolocoAdapterFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MolocoAdapterFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F04223722D494E4A005D2513 /* MolocoNativeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolocoNativeFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +182,7 @@
 				70E380E92C472410004CCB92 /* MolocoSdkImpl.swift */,
 				85AD79612CA5D967007358CE /* MolocoBannerFactory.swift */,
 				8566027E2C63F6FF0068D786 /* MolocoRewardedFactory.swift */,
+				F04223722D494E4A005D2513 /* MolocoNativeFactory.swift */,
 				706083C62C47CDB100896E93 /* MolocoInterstitialFactory.swift */,
 				70A1FA362CC343D300BC54D0 /* MolocoBidTokenGetter.swift */,
 				703876C82CF52724000C09EE /* MolocoSdkVersionProviding.swift */,
@@ -365,6 +369,7 @@
 				ADA6BA4D2CF146FE009C8FDA /* BannerAdLoader.swift in Sources */,
 				ADA6BA4E2CF146FE009C8FDA /* MolocoUtils.swift in Sources */,
 				ADA6BA4F2CF146FE009C8FDA /* MolocoSdkImpl.swift in Sources */,
+				F04223742D494E59005D2513 /* MolocoNativeFactory.swift in Sources */,
 				ADA6BA502CF146FE009C8FDA /* RewardedAdLoader.swift in Sources */,
 				ADA6BA512CF146FE009C8FDA /* MolocoBannerFactory.swift in Sources */,
 				ADA6BA522CF146FE009C8FDA /* MolocoBidTokenGetter.swift in Sources */,
@@ -388,6 +393,7 @@
 				7072CDE82C409510002BF6AE /* MolocoUtils.swift in Sources */,
 				70E380EA2C472410004CCB92 /* MolocoSdkImpl.swift in Sources */,
 				ADFA84C42C17704300A501AB /* RewardedAdLoader.swift in Sources */,
+				F04223732D494E59005D2513 /* MolocoNativeFactory.swift in Sources */,
 				85AD79622CA5D967007358CE /* MolocoBannerFactory.swift in Sources */,
 				70A1FA372CC343D300BC54D0 /* MolocoBidTokenGetter.swift in Sources */,
 				ADFA84BD2C17704300A501AB /* MolocoMediationAdapter.swift in Sources */,

--- a/adapters/Moloco/MolocoAdapter/MolocoMediationAdapter.swift
+++ b/adapters/Moloco/MolocoAdapter/MolocoMediationAdapter.swift
@@ -67,6 +67,11 @@ public final class MolocoMediationAdapter: NSObject, RTBAdapter {
   }
 
   /// Initializer used only for testing purpose.
+  init(molocoNativeFactory: MolocoNativeFactory) {
+    self.molocoNativeFactory = molocoNativeFactory
+  }
+
+  /// Initializer used only for testing purpose.
   init(molocoRewardedFactory: MolocoRewardedFactory) {
     self.molocoRewardedFactory = molocoRewardedFactory
   }

--- a/adapters/Moloco/MolocoAdapter/MolocoMediationAdapter.swift
+++ b/adapters/Moloco/MolocoAdapter/MolocoMediationAdapter.swift
@@ -45,6 +45,9 @@ public final class MolocoMediationAdapter: NSObject, RTBAdapter {
   /// Used to create Moloco rewarded ads.
   private var molocoRewardedFactory: MolocoRewardedFactory = MolocoMediationAdapter.molocoSdkImpl
 
+  /// Used to create Moloco native ads.
+  private var molocoNativeFactory: MolocoNativeFactory = MolocoMediationAdapter.molocoSdkImpl
+
   /// Used to create Moloco banner ads.
   private var molocoBannerFactory: MolocoBannerFactory = MolocoMediationAdapter.molocoSdkImpl
 
@@ -260,13 +263,12 @@ public final class MolocoMediationAdapter: NSObject, RTBAdapter {
     rewardedAdLoader?.loadAd()
   }
 
-  // TODO: Remove if not needed. If removed, then remove the |NativeAdLoader| class as well.
   @objc public func loadNativeAd(
     for adConfiguration: MediationNativeAdConfiguration,
     completionHandler: @escaping GADMediationNativeLoadCompletionHandler
   ) {
     nativeAdLoader = NativeAdLoader(
-      adConfiguration: adConfiguration, loadCompletionHandler: completionHandler)
+      adConfiguration: adConfiguration, loadCompletionHandler: completionHandler, molocoNativeFactory: molocoNativeFactory)
     nativeAdLoader?.loadAd()
   }
 

--- a/adapters/Moloco/MolocoAdapter/MolocoNativeFactory.swift
+++ b/adapters/Moloco/MolocoAdapter/MolocoNativeFactory.swift
@@ -1,0 +1,22 @@
+//
+//  MolocoNativeFactory.swift
+//  MolocoAdapter
+//
+//  Created by Vishal Dhiman on 1/28/25.
+//
+
+import Foundation
+import MolocoSDK
+
+/// Protocol for a factory of Moloco Native ads.
+public protocol MolocoNativeFactory {
+
+  @MainActor
+  @available(iOS 13.0, *)
+  func createNativeAd(for adUnit: String, delegate: MolocoNativeAdDelegate)
+    -> MolocoNativeAd?
+
+}
+
+
+

--- a/adapters/Moloco/MolocoAdapter/MolocoSdkImpl.swift
+++ b/adapters/Moloco/MolocoAdapter/MolocoSdkImpl.swift
@@ -73,6 +73,19 @@ extension MolocoSdkImpl: MolocoBannerFactory {
 
 }
 
+extension MolocoSdkImpl: MolocoNativeFactory {
+
+  @MainActor
+  @available(iOS 13.0, *)
+  func createNativeAd(for adUnit: String, delegate: MolocoNativeAdDelegate) -> MolocoNativeAd? {
+    guard let rootViewController = MolocoUtils.keyWindow()?.rootViewController else {
+      return nil
+    }
+
+    return Moloco.shared.createNativeAd(for: adUnit, delegate: delegate)
+  }
+  
+}
 // MARK: - MolocoBidTokenGetter
 
 extension MolocoSdkImpl: MolocoBidTokenGetter {

--- a/adapters/Moloco/MolocoAdapter/NativeAdLoader.swift
+++ b/adapters/Moloco/MolocoAdapter/NativeAdLoader.swift
@@ -33,7 +33,7 @@ final class NativeAdLoader: NSObject {
   private var nativeAd: MolocoNativeAd?
 
   init(
-    adConfiguration: GADMediationNativeAdConfiguration,
+    adConfiguration: MediationNativeAdConfiguration,
     loadCompletionHandler: @escaping GADMediationNativeLoadCompletionHandler,
     molocoNativeFactory: MolocoNativeFactory
   ) {
@@ -133,17 +133,17 @@ extension NativeAdLoader: MolocoNativeAdDelegate {
 
 // MARK: - GADMediationNativeAd
 
-extension NativeAdLoader: GADMediationNativeAd {
+extension NativeAdLoader: MediationNativeAd {
 
   var headline: String? {
     return self.nativeAd?.assets?.title
   }
 
-  var images: [GADNativeAdImage]? {
+  var images: [NativeAdImage]? {
     guard let mainImage = self.nativeAd?.assets?.mainImage else {
       return nil
     }
-    return [GADNativeAdImage(image: mainImage)]
+    return [NativeAdImage(image: mainImage)]
   }
 
   var mediaView: UIView? {
@@ -157,7 +157,7 @@ extension NativeAdLoader: GADMediationNativeAd {
     return self.nativeAd?.assets?.description
   }
 
-  var icon: GADNativeAdImage? {
+  var icon: NativeAdImage? {
     return self.nativeAd?.assets?.appIcon.map { .init(image: $0) }
   }
 
@@ -202,7 +202,7 @@ extension NativeAdLoader: GADMediationNativeAd {
   }
 
   func didRecordClickOnAsset(
-    withName assetName: GADNativeAssetIdentifier,
+    with assetName: GADNativeAssetIdentifier,
     view: UIView,
     viewController: UIViewController
   ) {


### PR DESCRIPTION
Sample PR to add Native ads suport to Google Ads Moloco Adapter.
Supports Moloco SDK 3.6.0 and above.

- This change adds support for Moloco adapter to have Native Ad support.
- The adapter is not tested by Moloco as native ads is not enabled
- Please do the verification before merging this change in. I had trouble establishing the build dependencies and prepared the adapter from our internal source without being able to compile the google project.