### PR TITLE
Native Assets test and a bug fix in StarRating computation.

### DIFF
--- a/AdapterUnitTests/AdapterUnitTests.xcodeproj/project.pbxproj
+++ b/AdapterUnitTests/AdapterUnitTests.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		F090AA192D6563F4003DB8CC /* FakeMolocoNativeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090AA182D6563F4003DB8CC /* FakeMolocoNativeFactory.swift */; };
 		F090AA1A2D6563F4003DB8CC /* FakeMolocoNativeAd.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090AA172D6563F4003DB8CC /* FakeMolocoNativeAd.swift */; };
 		F090AA1C2D656413003DB8CC /* MolocoNativeAdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090AA1B2D656413003DB8CC /* MolocoNativeAdTest.swift */; };
+		F0F0A7732D820B910004BE2E /* FakeMolocoNativeAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A7722D820B910004BE2E /* FakeMolocoNativeAssets.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -836,6 +837,7 @@
 		F090AA172D6563F4003DB8CC /* FakeMolocoNativeAd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMolocoNativeAd.swift; sourceTree = "<group>"; };
 		F090AA182D6563F4003DB8CC /* FakeMolocoNativeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMolocoNativeFactory.swift; sourceTree = "<group>"; };
 		F090AA1B2D656413003DB8CC /* MolocoNativeAdTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolocoNativeAdTest.swift; sourceTree = "<group>"; };
+		F0F0A7722D820B910004BE2E /* FakeMolocoNativeAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMolocoNativeAssets.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1041,6 +1043,7 @@
 				70608B4F2C51C64300896E93 /* FakeMolocoInterstitial.swift */,
 				70608B512C51C65900896E93 /* FakeMolocoInterstitialFactory.swift */,
 				F090AA172D6563F4003DB8CC /* FakeMolocoNativeAd.swift */,
+				F0F0A7722D820B910004BE2E /* FakeMolocoNativeAssets.swift */,
 				F090AA182D6563F4003DB8CC /* FakeMolocoNativeFactory.swift */,
 				856602EC2C642DE70068D786 /* FakeMolocoRewarded.swift */,
 				8526681D2C755D15000BBD3A /* FakeMolocoRewardedFactory.swift */,
@@ -2402,6 +2405,7 @@
 				70608B522C51C65900896E93 /* FakeMolocoInterstitialFactory.swift in Sources */,
 				ADAB37C12D23444400D407AB /* MolocoTestUtils.swift in Sources */,
 				706083C52C47CAAA00896E93 /* MolocoInterstitialAdTest.swift in Sources */,
+				F0F0A7732D820B910004BE2E /* FakeMolocoNativeAssets.swift in Sources */,
 				856602ED2C642DE70068D786 /* FakeMolocoRewarded.swift in Sources */,
 				85A57D712CA4B65E009FC260 /* FakeMolocoBanner.swift in Sources */,
 				8595C0C42C59A82B00B46FD2 /* MolocoRewardedAdTest.swift in Sources */,

--- a/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeAd.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeAd.swift
@@ -32,7 +32,7 @@ final class FakeMolocoNativeAd {
   // MolocoSDK.MolocoNativeAd properties.
   var nativeDelegate: (any MolocoSDK.MolocoNativeAdDelegate)?
   var isReady: Bool
-  var nativeAssets: MolocoNativeAdAssests? = nil
+  var nativeAssets: MolocoNativeAdAssests?
 
   /// If loadError is nil, this fake mimics load success. If loadError is not nil, this fake mimics
   /// load failure.
@@ -91,6 +91,7 @@ extension FakeMolocoNativeAd: MolocoSDK.MolocoNativeAd {
   func load(bidResponse: String) {
     bidResponseUsedToLoadMolocoAd = bidResponse
     guard let loadError else {
+      self.nativeAssets = FakeMolocoNativeAdAssests()
       nativeDelegate?.didLoad(ad: self)
       return
     }

--- a/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeAssets.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoNativeAssets.swift
@@ -1,0 +1,51 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import MolocoAdapter
+import MolocoSDK
+import UIKit
+
+  /// A fake implementation of MolocoNativeAdAssests that creates a FakeMolocoNativeAdAssests.
+final class FakeMolocoNativeAdAssests: MolocoNativeAdAssests {
+  var appIcon: UIImage? {
+    return UIImage()
+  }
+  
+  var mainImage: UIImage? {
+    return UIImage()
+  }
+  
+  var title: String = FakeAssetValues.title
+  
+  var description: String = FakeAssetValues.description
+  
+  var sponsorText: String = FakeAssetValues.sponsorText
+  
+  var ctaTitle: String = FakeAssetValues.ctaTitle
+  
+  var rating: Double = FakeAssetValues.rating
+  
+  var videoView: UIView? {
+    UIView()
+  }
+}
+
+class FakeAssetValues {
+  static var title = "FakeTitle"
+  static var description = "FakeDesc"
+  static var sponsorText = "FakeSponsor"
+  static var ctaTitle = "FakeCtaTitle"
+  static var rating = 4.5
+}

--- a/AdapterUnitTests/MolocoAdapterTests/MolocoNativeAdTest.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/MolocoNativeAdTest.swift
@@ -11,7 +11,7 @@ final class MolocoNativeAdTest: XCTestCase {
   /// A bid response received by the adapter to load the ad.
   static let testBidResponse = "bid_response"
 
-  func testNativeLoadSuccess() {
+  func loadNativeAd() -> AUTKMediationNativeAdEventDelegate {
     let molocoNativeFactory = FakeMolocoNativeFactory(loadError: nil)
     let adapter = MolocoMediationAdapter(molocoNativeFactory: molocoNativeFactory)
     let mediationAdConfig = AUTKMediationNativeAdConfiguration()
@@ -20,11 +20,16 @@ final class MolocoNativeAdTest: XCTestCase {
     mediationAdConfig.credentials = credentials
     mediationAdConfig.bidResponse = Self.testBidResponse
 
-    AUTKWaitAndAssertLoadNativeAd(adapter, mediationAdConfig)
+    let nativeAdEventDelegate =   AUTKWaitAndAssertLoadNativeAd(adapter, mediationAdConfig)
     XCTAssertEqual(molocoNativeFactory.adUnitIDUsedToCreateMolocoAd, Self.testAdUnitID)
     XCTAssertEqual(
       molocoNativeFactory.fakeMolocoNative?.bidResponseUsedToLoadMolocoAd, Self.testBidResponse
     )
+    return nativeAdEventDelegate
+  }
+  
+  func testNativeLoadSuccess() {
+    XCTAssertNotNil(loadNativeAd())
   }
 
   func testNativeLoadFailure_ifBidResponseIsMissing() {
@@ -101,6 +106,58 @@ final class MolocoNativeAdTest: XCTestCase {
     XCTAssertNil(adEventDelegate.didFailToPresentError)
     XCTAssertEqual(adEventDelegate.reportImpressionInvokeCount, 1)
     XCTAssertEqual(adEventDelegate.reportClickInvokeCount, 1)
+  }
+
+  func testIcon() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertTrue(nativeAd?.icon is NativeAdImage)
+  }
+
+  func testMediaView() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertTrue(nativeAd?.mediaView is UIView)
+  }
+
+  func testHeadline() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertEqual(nativeAd?.headline, FakeAssetValues.title)
+  }
+
+  func testBody() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertEqual(nativeAd?.body, FakeAssetValues.description)
+  }
+
+  func testCallToAction() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertEqual(nativeAd?.callToAction, FakeAssetValues.ctaTitle)
+  }
+
+  func testAdvertiser() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertEqual(nativeAd?.advertiser, FakeAssetValues.sponsorText)
+  }
+
+  func testStarRating() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+    XCTAssertEqual(nativeAd?.starRating?.doubleValue, FakeAssetValues.rating)
+  }
+
+  func testUnusedNativeAdMetaData() {
+    let eventDelegate = loadNativeAd()
+    let nativeAd = eventDelegate.nativeAd;
+
+    XCTAssertNil(nativeAd?.adChoicesView)
+    XCTAssertNil(nativeAd?.extraAssets)
+    XCTAssertNil(nativeAd?.price)
+    XCTAssertNil(nativeAd?.store)
   }
 
 }

--- a/adapters/Moloco/MolocoAdapter/NativeAdLoader.swift
+++ b/adapters/Moloco/MolocoAdapter/NativeAdLoader.swift
@@ -166,7 +166,10 @@ extension NativeAdLoader: MediationNativeAd {
   }
 
   var starRating: NSDecimalNumber? {
-    return self.nativeAd?.assets?.rating as? NSDecimalNumber
+    if let rating: Double = self.nativeAd?.assets?.rating {
+      return NSDecimalNumber(value: rating)
+    }
+    return nil
   }
 
   var store: String? {


### PR DESCRIPTION
Changes
- Adding required Native Ad Assets validation tests
- And corrected a bug that it Uncovered: 
  - The conversion logic from Double to NSDecimal Number was not working.
-  Passed the new and Existing tests.
