### PR TITLE
Add support for banner ads in maio iOS adapter

### DIFF
--- a/adapters/Maio/MaioAdapter.xcodeproj/project.pbxproj
+++ b/adapters/Maio/MaioAdapter.xcodeproj/project.pbxproj
@@ -71,6 +71,12 @@
 		C29F392D1FB996CD00A32028 /* GADMMaioRewardedAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = C29F39221FB98B2F00A32028 /* GADMMaioRewardedAdapter.h */; };
 		C29F39301FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = C29F392E1FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.h */; };
 		C29F39311FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = C29F392F1FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.m */; };
+		E2751CA02EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m in Sources */ = {isa = PBXBuildFile; fileRef = E2751C9F2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m */; };
+		E2751CA12EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h in Headers */ = {isa = PBXBuildFile; fileRef = E2751C9E2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h */; };
+		E2751CA22EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h in Headers */ = {isa = PBXBuildFile; fileRef = E2751C9E2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h */; };
+		E2751CA32EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m in Sources */ = {isa = PBXBuildFile; fileRef = E2751C9F2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m */; };
+		E2751CA42EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m in Sources */ = {isa = PBXBuildFile; fileRef = E2751C9F2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m */; };
+		E2751CA52EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h in Headers */ = {isa = PBXBuildFile; fileRef = E2751C9E2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -142,6 +148,8 @@
 		C29F39221FB98B2F00A32028 /* GADMMaioRewardedAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMMaioRewardedAdapter.h; sourceTree = "<group>"; };
 		C29F392E1FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMMaioInterstitialAdapter.h; sourceTree = "<group>"; };
 		C29F392F1FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMMaioInterstitialAdapter.m; sourceTree = "<group>"; };
+		E2751C9E2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GADMAdapterMaioBannerAd.h; sourceTree = "<group>"; };
+		E2751C9F2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GADMAdapterMaioBannerAd.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +222,8 @@
 		7D72B8C11DB97C10006EAE11 /* MaioAdapter */ = {
 			isa = PBXGroup;
 			children = (
+				E2751C9E2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h */,
+				E2751C9F2EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m */,
 				ADA1B0922B2BC4ED00CA4FC8 /* GADMAdapterMaioInterstitialAd.h */,
 				ADA1B0932B2BC52E00CA4FC8 /* GADMAdapterMaioInterstitialAd.m */,
 				45E6353A22309EFE006EB5A1 /* GADMAdapterMaioRewardedAd.h */,
@@ -275,6 +285,7 @@
 			files = (
 				3582A58D1FB2355D00490786 /* MaioAdapter.h in Headers */,
 				C29F39281FB996CD00A32028 /* GADMMaioConstants.h in Headers */,
+				E2751CA12EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h in Headers */,
 				45E6353822309EAE006EB5A1 /* GADMediationAdapterMaio.h in Headers */,
 				C29F392D1FB996CD00A32028 /* GADMMaioRewardedAdapter.h in Headers */,
 				45E6353C22309EFE006EB5A1 /* GADMAdapterMaioRewardedAd.h in Headers */,
@@ -296,6 +307,7 @@
 			files = (
 				AD6E39292EA1670F00818296 /* MaioAdapter.h in Headers */,
 				AD6E392B2EA1670F00818296 /* GADMMaioConstants.h in Headers */,
+				E2751CA52EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h in Headers */,
 				AD6E392C2EA1670F00818296 /* GADMediationAdapterMaio.h in Headers */,
 				AD6E392D2EA1670F00818296 /* GADMMaioRewardedAdapter.h in Headers */,
 				AD6E392F2EA1670F00818296 /* GADMAdapterMaioRewardedAd.h in Headers */,
@@ -310,6 +322,7 @@
 			files = (
 				ADA6B9F62CF146D9009C8FDA /* MaioAdapter.h in Headers */,
 				ADA6B9F82CF146D9009C8FDA /* GADMMaioConstants.h in Headers */,
+				E2751CA22EE9649D0097EE41 /* GADMAdapterMaioBannerAd.h in Headers */,
 				ADA6B9F92CF146D9009C8FDA /* GADMediationAdapterMaio.h in Headers */,
 				ADA6B9FA2CF146D9009C8FDA /* GADMMaioRewardedAdapter.h in Headers */,
 				ADA6B9FC2CF146D9009C8FDA /* GADMAdapterMaioRewardedAd.h in Headers */,
@@ -488,6 +501,7 @@
 				45E6353922309EAE006EB5A1 /* GADMediationAdapterMaio.m in Sources */,
 				ADA1B0942B2BC52E00CA4FC8 /* GADMAdapterMaioInterstitialAd.m in Sources */,
 				00AC999322E923F300262599 /* GADMAdapterMaioUtils.m in Sources */,
+				E2751CA02EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m in Sources */,
 				C29F39311FB9BEDC00A32028 /* GADMMaioInterstitialAdapter.m in Sources */,
 				C29F39271FB996B400A32028 /* GADMMaioRewardedAdapter.m in Sources */,
 			);
@@ -508,6 +522,7 @@
 				AD6E39202EA1670F00818296 /* GADMediationAdapterMaio.m in Sources */,
 				AD6E39212EA1670F00818296 /* GADMAdapterMaioInterstitialAd.m in Sources */,
 				AD6E39222EA1670F00818296 /* GADMAdapterMaioUtils.m in Sources */,
+				E2751CA42EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m in Sources */,
 				AD6E39232EA1670F00818296 /* GADMMaioInterstitialAdapter.m in Sources */,
 				AD6E39252EA1670F00818296 /* GADMMaioRewardedAdapter.m in Sources */,
 			);
@@ -521,6 +536,7 @@
 				ADA6B9ED2CF146D9009C8FDA /* GADMediationAdapterMaio.m in Sources */,
 				ADA6B9EE2CF146D9009C8FDA /* GADMAdapterMaioInterstitialAd.m in Sources */,
 				ADA6B9EF2CF146D9009C8FDA /* GADMAdapterMaioUtils.m in Sources */,
+				E2751CA32EE9649D0097EE41 /* GADMAdapterMaioBannerAd.m in Sources */,
 				ADA6B9F02CF146D9009C8FDA /* GADMMaioInterstitialAdapter.m in Sources */,
 				ADA6B9F22CF146D9009C8FDA /* GADMMaioRewardedAdapter.m in Sources */,
 			);

--- a/adapters/Maio/MaioAdapter/GADMAdapterMaioBannerAd.h
+++ b/adapters/Maio/MaioAdapter/GADMAdapterMaioBannerAd.h
@@ -1,0 +1,23 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <GoogleMobileAds/GoogleMobileAds.h>
+
+@interface GADMAdapterMaioBannerAd : NSObject <GADMediationBannerAd>
+
+- (void)loadBannerAdForAdConfiguration:(GADMediationBannerAdConfiguration *)adConfiguration
+                     completionHandler:(GADMediationBannerLoadCompletionHandler)completionHandler;
+
+@end

--- a/adapters/Maio/MaioAdapter/GADMAdapterMaioBannerAd.m
+++ b/adapters/Maio/MaioAdapter/GADMAdapterMaioBannerAd.m
@@ -1,0 +1,136 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GADMAdapterMaioBannerAd.h"
+
+#import <Maio/Maio-Swift.h>
+#import <stdatomic.h>
+
+#import "GADMAdapterMaioUtils.h"
+#import "GADMMaioConstants.h"
+
+@interface GADMAdapterMaioBannerAd () <MaioBannerDelegate>
+
+@property(nonatomic, copy) GADMediationBannerLoadCompletionHandler completionHandler;
+@property(nonatomic, weak) id<GADMediationBannerAdEventDelegate> adEventDelegate;
+
+@property(nonatomic) MaioBannerView *maioBannerView;
+
+@end
+
+@implementation GADMAdapterMaioBannerAd
+
+- (void)loadBannerAdForAdConfiguration:(GADMediationBannerAdConfiguration *)adConfiguration
+                     completionHandler:(GADMediationBannerLoadCompletionHandler)completionHandler {
+  // Safe handling of completionHandler from CONTRIBUTING.md#best-practices
+  __block atomic_flag completionHandlerCalled = ATOMIC_FLAG_INIT;
+  __block GADMediationBannerLoadCompletionHandler originalCompletionHandler =
+      [completionHandler copy];
+  self.completionHandler = ^id<GADMediationBannerAdEventDelegate>(
+      _Nullable id<GADMediationBannerAd> ad, NSError *_Nullable error) {
+    // Only allow completion handler to be called once.
+    if (atomic_flag_test_and_set(&completionHandlerCalled)) {
+      return nil;
+    }
+
+    id<GADMediationBannerAdEventDelegate> delegate = nil;
+    if (originalCompletionHandler) {
+      // Call original handler and hold on to its return value.
+      delegate = originalCompletionHandler(ad, error);
+    }
+    // Release reference to handler. Objects retained by the handler will also be released.
+    originalCompletionHandler = nil;
+
+    return delegate;
+  };
+
+  NSString *zoneId = adConfiguration.credentials.settings[GADMMaioAdapterZoneIdKey];
+  MaioBannerSize *maioBannerSize =
+      [GADMAdapterMaioUtils maioAdSizeFromRequestedSize:adConfiguration.adSize];
+
+  if (maioBannerSize == nil) {
+    NSString *description =
+        [NSString stringWithFormat:@"Unsupported ad size requested for maio. Requested size: %@",
+         NSStringFromGADAdSize(adConfiguration.adSize)];
+    NSDictionary *userInfo =
+      @{NSLocalizedDescriptionKey : description, NSLocalizedFailureReasonErrorKey : description};
+    NSError *error = [NSError errorWithDomain:GADMMaioSDKErrorDomain
+                                         code:0
+                                     userInfo:userInfo];
+
+    NSLog(@"maio banner ad failed to load with error code: %@", error);
+    self.completionHandler(nil, error);
+    return;
+  }
+
+  self.maioBannerView = [[MaioBannerView alloc] initWithZoneId:zoneId size:maioBannerSize];
+  self.maioBannerView.delegate = self;
+  self.maioBannerView.rootViewController = adConfiguration.topViewController;
+
+  [self.maioBannerView loadWithTestMode:adConfiguration.isTestRequest bidData:nil];
+}
+
+#pragma mark - GADMediationBannerAd
+
+- (UIView *)view {
+  self.maioBannerView.translatesAutoresizingMaskIntoConstraints = NO;
+  return self.maioBannerView;
+}
+
+#pragma mark - MaioBannerDelegate
+
+- (void)didLoad:(MaioBannerView *)ad {
+  self.adEventDelegate = self.completionHandler(self, nil);
+}
+
+- (void)didFailToLoad:(MaioBannerView *)ad errorCode:(NSInteger)errorCode {
+  NSString *description = @"maio SDK returned an error.";
+  NSDictionary *userInfo =
+      @{NSLocalizedDescriptionKey : description, NSLocalizedFailureReasonErrorKey : description};
+  NSError *error = [NSError errorWithDomain:GADMMaioSDKErrorDomain
+                                       code:errorCode
+                                   userInfo:userInfo];
+
+  NSLog(@"maio banner ad failed to load with error code: %@", error);
+  self.completionHandler(nil, error);
+}
+
+- (void)didMakeImpression:(MaioBannerView *)ad {
+  id<GADMediationBannerAdEventDelegate> adEventDelegate = self.adEventDelegate;
+  [adEventDelegate reportImpression];
+}
+
+- (void)didClick:(MaioBannerView *)ad {
+  id<GADMediationBannerAdEventDelegate> adEventDelegate = self.adEventDelegate;
+  [adEventDelegate reportClick];
+}
+
+- (void)didLeaveApplication:(MaioBannerView *)ad {
+  id<GADMediationBannerAdEventDelegate> adEventDelegate = self.adEventDelegate;
+  [adEventDelegate willDismissFullScreenView];
+}
+
+- (void)didFailToShow:(MaioBannerView *)ad errorCode:(NSInteger)errorCode {
+  NSString *description = @"maio SDK returned an error.";
+  NSDictionary *userInfo =
+      @{NSLocalizedDescriptionKey : description, NSLocalizedFailureReasonErrorKey : description};
+  NSError *error = [NSError errorWithDomain:GADMMaioSDKErrorDomain
+                                       code:errorCode
+                                   userInfo:userInfo];
+
+  NSLog(@"maio banner ad failed to show with error code: %@", error);
+  self.completionHandler(nil, error);
+}
+
+@end

--- a/adapters/Maio/MaioAdapter/GADMAdapterMaioUtils.h
+++ b/adapters/Maio/MaioAdapter/GADMAdapterMaioUtils.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import <GoogleMobileAds/GoogleMobileAds.h>
+#import <Maio/Maio-Swift.h>
 #import "GADMediationAdapterMaio.h"
 
 /// Adds |object| to |set| if |object| is not nil.
@@ -33,3 +35,10 @@ void GADMAdapterMaioMapTableSetObjectForKey(NSMapTable *_Nonnull mapTable,
 /// NSLocalizedFailureReasonErrorKey values set to |description|.
 NSError *_Nonnull GADMAdapterMaioErrorWithCodeAndDescription(GADMAdapterMaioErrorCode code,
                                                              NSString *_Nonnull description);
+
+@interface GADMAdapterMaioUtils : NSObject
+
+// maio Util methods.
++ (nullable MaioBannerSize *)maioAdSizeFromRequestedSize:(GADAdSize)size;
+
+@end

--- a/adapters/Maio/MaioAdapter/GADMAdapterMaioUtils.m
+++ b/adapters/Maio/MaioAdapter/GADMAdapterMaioUtils.m
@@ -50,3 +50,32 @@ NSError *_Nonnull GADMAdapterMaioErrorWithCodeAndDescription(GADMAdapterMaioErro
   NSError *error = [NSError errorWithDomain:GADMMaioErrorDomain code:code userInfo:userInfo];
   return error;
 }
+
+@implementation GADMAdapterMaioUtils
+
++ (nullable MaioBannerSize *)maioAdSizeFromRequestedSize:(GADAdSize)size {
+  GADAdSize banner = GADAdSizeBanner;
+  GADAdSize large = GADAdSizeLargeBanner;
+  GADAdSize rectangle = GADAdSizeMediumRectangle;
+
+  NSArray<NSValue *> *potentials = @[
+    NSValueFromGADAdSize(banner), NSValueFromGADAdSize(large), NSValueFromGADAdSize(rectangle)
+  ];
+
+  GADAdSize closestSize = GADClosestValidSizeForAdSizes(size, potentials);
+  CGSize closestCGSize = CGSizeFromGADAdSize(closestSize);
+  if (CGSizeEqualToSize(CGSizeFromGADAdSize(banner), closestCGSize)) {
+    return [MaioBannerSize banner];
+  }
+  if (CGSizeEqualToSize(CGSizeFromGADAdSize(large), closestCGSize)) {
+    return [MaioBannerSize bigBanner];
+  }
+  if (CGSizeEqualToSize(CGSizeFromGADAdSize(rectangle), closestCGSize)) {
+    return [MaioBannerSize mediumRectangle];
+  }
+
+  NSLog(@"Unable to retrieve maio size from GADAdSize: %@", NSStringFromGADAdSize(size));
+  return nil;
+}
+
+@end

--- a/adapters/Maio/MaioAdapter/GADMediationAdapterMaio.m
+++ b/adapters/Maio/MaioAdapter/GADMediationAdapterMaio.m
@@ -16,6 +16,7 @@
 
 #import <Maio/Maio-Swift.h>
 
+#import "GADMAdapterMaioBannerAd.h"
 #import "GADMAdapterMaioInterstitialAd.h"
 #import "GADMAdapterMaioRewardedAd.h"
 #import "GADMAdapterMaioUtils.h"
@@ -30,6 +31,9 @@
 
   // maio waterfall rewarded ad wrapper.
   GADMAdapterMaioRewardedAd *_rewardedAd;
+
+  // maio waterfall banner ad wrapper.
+  GADMAdapterMaioBannerAd *_bannerAd;
 }
 
 + (void)setUpWithConfiguration:(GADMediationServerConfiguration *)configuration
@@ -69,7 +73,9 @@
 
 - (void)loadBannerForAdConfiguration:(GADMediationBannerAdConfiguration *)adConfiguration
                    completionHandler:(GADMediationBannerLoadCompletionHandler)completionHandler {
-  // TODO: implement banner.
+  _bannerAd = [[GADMAdapterMaioBannerAd alloc] init];
+  [_bannerAd loadBannerAdForAdConfiguration:adConfiguration
+                          completionHandler:completionHandler];
 }
 
 - (void)loadRewardedAdForAdConfiguration:


### PR DESCRIPTION
This PR updates the adapter to support banner ads, a new feature added to the maio SDK.