### PR TITLE
update callbacks to align with BidMachine SDK callback behavior

### DIFF
--- a/adapters/BidMachine/BidMachineAdapter/BannerAdLoader.swift
+++ b/adapters/BidMachine/BidMachineAdapter/BannerAdLoader.swift
@@ -25,9 +25,6 @@ final class BannerAdLoader: NSObject, MediationBannerAd, @unchecked Sendable {
   /// Ads SDK.
   private weak var eventDelegate: MediationBannerAdEventDelegate?
 
-  /// The completion handler that needs to be called upon finishing loading an ad.
-  private var bannerAdLoadCompletionHandler: ((MediationBannerAd?, NSError?) -> Void)?
-
   /// The queue for processing an ad load completion.
   private let adLoadCompletionQueue: DispatchQueue
 
@@ -118,7 +115,7 @@ final class BannerAdLoader: NSObject, MediationBannerAd, @unchecked Sendable {
 
 extension BannerAdLoader: BidMachineAdDelegate {
 
-  func didLoadAd(_ ad: any BidMachine.BidMachineAdProtocol) {
+  func didLoadAd(_ ad: any BidMachineAdProtocol) {
     guard let bannerAd = ad as? UIView else {
       // Technically, should never get here.
       handleLoadedAd(
@@ -133,7 +130,7 @@ extension BannerAdLoader: BidMachineAdDelegate {
     handleLoadedAd(self, error: nil)
   }
 
-  func didFailLoadAd(_ ad: any BidMachine.BidMachineAdProtocol, _ error: any Error) {
+  func didFailLoadAd(_ ad: any BidMachineAdProtocol, _ error: any Error) {
     handleLoadedAd(nil, error: error)
   }
 
@@ -142,6 +139,10 @@ extension BannerAdLoader: BidMachineAdDelegate {
   }
 
   func didTrackInteraction(_ ad: any BidMachineAdProtocol) {
+      // Is called only on first click. If you need to track every click use didUserInteraction instead
+  }
+
+  func didUserInteraction(_ ad: any BidMachineAdProtocol) {
     eventDelegate?.reportClick()
   }
 
@@ -149,4 +150,12 @@ extension BannerAdLoader: BidMachineAdDelegate {
     eventDelegate?.didFailToPresentWithError(error)
   }
 
+  func willPresentScreen(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.willPresentFullScreenView()
+  }
+
+  func didDismissScreen(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.willDismissFullScreenView()
+    eventDelegate?.didDismissFullScreenView()
+  }
 }

--- a/adapters/BidMachine/BidMachineAdapter/InterstitialAdLoader.swift
+++ b/adapters/BidMachine/BidMachineAdapter/InterstitialAdLoader.swift
@@ -123,33 +123,45 @@ extension InterstitialAdLoader: MediationInterstitialAd {
 
 extension InterstitialAdLoader: BidMachineAdDelegate {
 
-  func didLoadAd(_ ad: any BidMachine.BidMachineAdProtocol) {
+  func didLoadAd(_ ad: any BidMachineAdProtocol) {
     interstitialAd = ad as? BidMachineInterstitial
     handleLoadedAd(self, error: nil)
   }
 
-  func didFailLoadAd(_ ad: any BidMachine.BidMachineAdProtocol, _ error: any Error) {
+  func didFailLoadAd(_ ad: any BidMachineAdProtocol, _ error: any Error) {
     handleLoadedAd(nil, error: error as NSError)
   }
 
-  func didTrackImpression(_ ad: any BidMachineAdProtocol) {
-    eventDelegate?.reportImpression()
-  }
-
-  func didTrackInteraction(_ ad: any BidMachineAdProtocol) {
-    eventDelegate?.reportClick()
-  }
-
-  func willPresentScreen(_ ad: any BidMachineAdProtocol) {
+  func didPresentAd(_ ad: any BidMachineAdProtocol) {
     eventDelegate?.willPresentFullScreenView()
-  }
-
-  func didDismissAd(_ ad: any BidMachineAdProtocol) {
-    eventDelegate?.didDismissFullScreenView()
   }
 
   func didFailPresentAd(_ ad: any BidMachineAdProtocol, _ error: any Error) {
     eventDelegate?.didFailToPresentWithError(error)
   }
 
+  func didDismissAd(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.willDismissFullScreenView()
+    eventDelegate?.didDismissFullScreenView()
+  }
+
+  func willPresentScreen(_ ad: any BidMachineAdProtocol) {
+    // NO-OP
+  }
+
+  func didDismissScreen(_ ad: any BidMachineAdProtocol) {
+    // NO-OP
+  }
+
+  func didUserInteraction(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.reportClick()
+  }
+
+  func didTrackInteraction(_ ad: any BidMachineAdProtocol) {
+    // Is called only on first click. If you need to track every click use didUserInteraction instead
+  }
+
+  func didTrackImpression(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.reportImpression()
+  }
 }

--- a/adapters/BidMachine/BidMachineAdapter/NativeAdLoader.swift
+++ b/adapters/BidMachine/BidMachineAdapter/NativeAdLoader.swift
@@ -25,9 +25,6 @@ final class NativeAdLoader: NSObject {
   /// Ads SDK.
   private weak var eventDelegate: MediationNativeAdEventDelegate?
 
-  /// The completion handler that needs to be called upon finishing loading an ad.
-  private var nativeAdLoadCompletionHandler: ((MediationNativeAd?, NSError?) -> Void)?
-
   /// The queue for processing an ad load completion.
   private let adLoadCompletionQueue: DispatchQueue
 
@@ -112,7 +109,7 @@ final class NativeAdLoader: NSObject {
 
 extension NativeAdLoader: BidMachineAdDelegate {
 
-  func didLoadAd(_ ad: any BidMachine.BidMachineAdProtocol) {
+  func didLoadAd(_ ad: any BidMachineAdProtocol) {
     // BidMachine native ad's image assets come in string URLs. The adapter
     // needs to download them before notifying Google Mobile Ads SDK.
     do {
@@ -132,7 +129,7 @@ extension NativeAdLoader: BidMachineAdDelegate {
     }
   }
 
-  func didFailLoadAd(_ ad: any BidMachine.BidMachineAdProtocol, _ error: any Error) {
+  func didFailLoadAd(_ ad: any BidMachineAdProtocol, _ error: any Error) {
     handleLoadedAd(nil, error: error as NSError)
   }
 
@@ -141,6 +138,10 @@ extension NativeAdLoader: BidMachineAdDelegate {
   }
 
   func didTrackInteraction(_ ad: any BidMachineAdProtocol) {
+    // Is called only on first click. If you need to track every click use didUserInteraction instead
+  }
+
+  func didUserInteraction(_ ad: any BidMachineAdProtocol) {
     eventDelegate?.reportClick()
   }
 
@@ -148,4 +149,12 @@ extension NativeAdLoader: BidMachineAdDelegate {
     eventDelegate?.didFailToPresentWithError(error)
   }
 
+  func willPresentScreen(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.willPresentFullScreenView()
+  }
+
+  func didDismissScreen(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.willDismissFullScreenView()
+    eventDelegate?.didDismissFullScreenView()
+  }
 }

--- a/adapters/BidMachine/BidMachineAdapter/RewardedAdLoader.swift
+++ b/adapters/BidMachine/BidMachineAdapter/RewardedAdLoader.swift
@@ -25,9 +25,6 @@ final class RewardedAdLoader: NSObject {
   /// Mobile Ads SDK.
   private weak var eventDelegate: MediationRewardedAdEventDelegate?
 
-  /// The completion handler that needs to be called upon finishing loading an ad.
-  private var rewardedAdLoadCompletionHandler: ((MediationRewardedAd?, NSError?) -> Void)?
-
   /// The queue for processing an ad load completion.
   private let adLoadCompletionQueue: DispatchQueue
 
@@ -125,34 +122,46 @@ extension RewardedAdLoader: MediationRewardedAd {
 // MARK: - BidMachineAdDelegate
 
 extension RewardedAdLoader: BidMachineAdDelegate {
-
-  func didLoadAd(_ ad: any BidMachine.BidMachineAdProtocol) {
+  func didLoadAd(_ ad: any BidMachineAdProtocol) {
     rewardedAd = ad as? BidMachineRewarded
     handleLoadedAd(self, error: nil)
   }
 
-  func didFailLoadAd(_ ad: any BidMachine.BidMachineAdProtocol, _ error: any Error) {
+  func didFailLoadAd(_ ad: any BidMachineAdProtocol, _ error: any Error) {
     handleLoadedAd(nil, error: error as NSError)
   }
 
-  func didTrackImpression(_ ad: any BidMachineAdProtocol) {
-    eventDelegate?.reportImpression()
-  }
-
-  func didTrackInteraction(_ ad: any BidMachineAdProtocol) {
-    eventDelegate?.reportClick()
-  }
-
-  func willPresentScreen(_ ad: any BidMachineAdProtocol) {
+  func didPresentAd(_ ad: any BidMachineAdProtocol) {
     eventDelegate?.willPresentFullScreenView()
-  }
-
-  func didDismissAd(_ ad: any BidMachineAdProtocol) {
-    eventDelegate?.didDismissFullScreenView()
   }
 
   func didFailPresentAd(_ ad: any BidMachineAdProtocol, _ error: any Error) {
     eventDelegate?.didFailToPresentWithError(error)
+  }
+
+  func didDismissAd(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.willDismissFullScreenView()
+    eventDelegate?.didDismissFullScreenView()
+  }
+
+  func willPresentScreen(_ ad: any BidMachineAdProtocol) {
+    // NO-OP
+  }
+
+  func didDismissScreen(_ ad: any BidMachineAdProtocol) {
+    // NO-OP
+  }
+
+  func didUserInteraction(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.reportClick()
+  }
+
+  func didTrackInteraction(_ ad: any BidMachineAdProtocol) {
+    // Is called only on first click. If you need to track every click use didUserInteraction instead
+  }
+
+  func didTrackImpression(_ ad: any BidMachineAdProtocol) {
+    eventDelegate?.reportImpression()
   }
 
   func didReceiveReward(_ ad: any BidMachineAdProtocol) {


### PR DESCRIPTION
## Scope of Changes
`BidMachineAdDelegate` conformance sections were modified to align with BidMachine SDK callback behavior. `BannerAdLoader`, `RewardedAdLoader`, `NativeAdLoader` were modified to eanup dead code

## Updated Files
* `RewardedAdLoader.swift`
* `BannerAdLoader.swift`
* `NativeAdLoader.swift`
* `InterstitialAdLoader.swift`

## Detailed Changes
### Dead code
Removed:

* `bannerAdLoadCompletionHandler`
* `nativeAdLoadCompletionHandler`
* `rewardedAdLoadCompletionHandler`

### Click Tracking: `eventDelegate?.reportClick()`
Updated in: InterstitialAdLoader, RewardedAdLoader, BannerAdLoader, NativeAdLoader

* Change: Moved from `didTrackInteraction` to `didUserInteraction`
* Reason:
  
  * `didTrackInteraction` is only called on the first click
  * `didUserInteraction` is called on every user click/interaction
  * This ensures all user interactions are properly reported to the mediation layer

### Full Screen Presentation: `eventDelegate?.willPresentFullScreenView()`
For Interstitial & Rewarded (InterstitialAdLoader, RewardedAdLoader):

* Change: Moved from `willPresentScreen` to `didPresentAd`
* Reason: These are fullscreen ad formats. The callback should fire when the ad itself is presented, not when a secondary modal screen appears. This fixes impression tracking.

For Banner & Native (BannerAdLoader, NativeAdLoader):

* Change: Added to `willPresentScreen`
* Reason: For banner and native formats, this callback should fire when a modal view is about to be presented on top of the ad.

### Full Screen Dismissal: `eventDelegate?.willDismissFullScreenView()`
For Interstitial & Rewarded (InterstitialAdLoader, RewardedAdLoader):

* Change: Added to `didDismissAd`
* Reason: Notifies the mediation layer when the fullscreen ad itself is dismissed.

For Banner & Native (BannerAdLoader, NativeAdLoader):

* Change: Added to `didDismissScreen`
* Reason: Notifies the mediation layer when the modal view is dismissed.