### PR TITLE
[Moloco] Add adaptive banner support and update to Moloco SDK 4.8.0

### DIFF
--- a/AdapterUnitTests/AdapterUnitTests.xcodeproj/project.pbxproj
+++ b/AdapterUnitTests/AdapterUnitTests.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		856602ED2C642DE70068D786 /* FakeMolocoRewarded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856602EC2C642DE70068D786 /* FakeMolocoRewarded.swift */; };
 		8595C0C42C59A82B00B46FD2 /* MolocoRewardedAdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8595C0C32C59A82B00B46FD2 /* MolocoRewardedAdTest.swift */; };
 		85A57D6F2CA4B640009FC260 /* MolocoBannerAdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A57D6E2CA4B640009FC260 /* MolocoBannerAdTest.swift */; };
+		BA11E70F2CA4B640009FC260 /* BannerAdLoaderResolvedFormatTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA11E70E2CA4B640009FC260 /* BannerAdLoaderResolvedFormatTest.swift */; };
 		85A57D712CA4B65E009FC260 /* FakeMolocoBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A57D702CA4B65E009FC260 /* FakeMolocoBanner.swift */; };
 		85A57D732CA4B663009FC260 /* FakeMolocoBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A57D722CA4B663009FC260 /* FakeMolocoBannerFactory.swift */; };
 		AD0123302ABCB0D8002BFE6D /* AUTMintegralAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AD01232F2ABCB0D8002BFE6D /* AUTMintegralAdapterTests.m */; };
@@ -1598,6 +1599,7 @@
 		856602EC2C642DE70068D786 /* FakeMolocoRewarded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeMolocoRewarded.swift; sourceTree = "<group>"; };
 		8595C0C32C59A82B00B46FD2 /* MolocoRewardedAdTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolocoRewardedAdTest.swift; sourceTree = "<group>"; };
 		85A57D6E2CA4B640009FC260 /* MolocoBannerAdTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MolocoBannerAdTest.swift; sourceTree = "<group>"; };
+		BA11E70E2CA4B640009FC260 /* BannerAdLoaderResolvedFormatTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerAdLoaderResolvedFormatTest.swift; sourceTree = "<group>"; };
 		85A57D702CA4B65E009FC260 /* FakeMolocoBanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeMolocoBanner.swift; sourceTree = "<group>"; };
 		85A57D722CA4B663009FC260 /* FakeMolocoBannerFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeMolocoBannerFactory.swift; sourceTree = "<group>"; };
 		AD0123172ABCB0AD002BFE6D /* MintegralAdapter.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MintegralAdapter.xcodeproj; path = ../adapters/MintegralAdapter/MintegralAdapter.xcodeproj; sourceTree = "<group>"; };
@@ -2387,6 +2389,7 @@
 				ADAB37C02D23444000D407AB /* MolocoTestUtils.swift */,
 				70608B4E2C51C5FC00896E93 /* Fakes */,
 				85A57D6E2CA4B640009FC260 /* MolocoBannerAdTest.swift */,
+				BA11E70E2CA4B640009FC260 /* BannerAdLoaderResolvedFormatTest.swift */,
 				70E380AF2C46FB8E004CCB92 /* MolocoMediationAdapterTest.swift */,
 				706083C42C47CAAA00896E93 /* MolocoInterstitialAdTest.swift */,
 				F090AA1B2D656413003DB8CC /* MolocoNativeAdTest.swift */,
@@ -5161,6 +5164,7 @@
 				85A57D712CA4B65E009FC260 /* FakeMolocoBanner.swift in Sources */,
 				8595C0C42C59A82B00B46FD2 /* MolocoRewardedAdTest.swift in Sources */,
 				85A57D6F2CA4B640009FC260 /* MolocoBannerAdTest.swift in Sources */,
+				BA11E70F2CA4B640009FC260 /* BannerAdLoaderResolvedFormatTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AdapterUnitTests/MolocoAdapterTests/BannerAdLoaderResolvedFormatTest.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/BannerAdLoaderResolvedFormatTest.swift
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleMobileAds
+import XCTest
+
+@testable import MolocoAdapter
+
+/// Tests for `BannerAdLoader.resolvedBannerFormat(from:)`, the pure mapping from
+/// a Google `AdSize` to the Moloco banner format.
+@available(iOS 13.0, *)
+final class BannerAdLoaderResolvedFormatTest: XCTestCase {
+
+  static let testWidth: CGFloat = 375
+
+  /// Asserts an anchored adaptive `AdSize` resolves to `.anchoredAdaptive`.
+  /// Skips (rather than fails) when the anchored height for this device equals a
+  /// fixed banner height (50 / 90): the resolver deliberately maps that overlap
+  /// to `.standard`, so the outcome is device-dependent by design.
+  private func assertResolvesToAnchored(_ adSize: AdSize) throws {
+    let height = adSize.size.height
+    try XCTSkipIf(
+      height == AdSizeBanner.size.height || height == AdSizeLeaderboard.size.height,
+      "Anchored height (\(height)) collides with a fixed banner height on this device; the "
+        + "resolver maps it to .standard by design.")
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: adSize), .anchoredAdaptive)
+  }
+
+  func testStandardBannerResolvesToStandard() {
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: AdSizeBanner), .standard)
+  }
+
+  func testMediumRectangleResolvesToMREC() {
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: AdSizeMediumRectangle), .mrec)
+  }
+
+  func testFullWidthFixedHeightBannerResolvesToStandard() {
+    let adSize = adSizeFor(cgSize: CGSize(width: 408, height: AdSizeBanner.size.height))
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: adSize), .standard)
+  }
+
+  func testLeaderboardResolvesToStandard() {
+    // Moloco has no leaderboard type; a leaderboard-height banner is treated as
+    // a fixed (standard) banner rather than adaptive.
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: AdSizeLeaderboard), .standard)
+  }
+
+  func testFullWidthLeaderboardHeightBannerResolvesToStandard() {
+    let adSize = adSizeFor(cgSize: CGSize(width: 408, height: AdSizeLeaderboard.size.height))
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: adSize), .standard)
+  }
+
+  func testLargeAnchoredResolvesToAnchored() throws {
+    try assertResolvesToAnchored(largeAnchoredAdaptiveBanner(width: Self.testWidth))
+  }
+
+  func testLargePortraitAnchoredResolvesToAnchored() throws {
+    try assertResolvesToAnchored(largePortraitAnchoredAdaptiveBanner(width: Self.testWidth))
+  }
+
+  func testLargeLandscapeAnchoredResolvesToAnchored() throws {
+    try assertResolvesToAnchored(largeLandscapeAnchoredAdaptiveBanner(width: Self.testWidth))
+  }
+
+  func testInlineAdaptiveResolvesToInline() {
+    let adSize = inlineAdaptiveBanner(width: Self.testWidth, maxHeight: 400)
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: adSize), .inlineAdaptive)
+  }
+
+  func testDegenerateSizeResolvesToStandard() {
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: adSizeFor(cgSize: .zero)), .standard)
+  }
+
+  func testOutOfRangeWidthResolvesToStandard() {
+    // A finite-but-huge width (e.g. a fluid / invalid sentinel) must be rejected
+    // by the width bound so it never reaches the `Int(width)` conversion. The
+    // height (250) is neither a fixed nor an anchored height, so without the
+    // bound this would resolve to `.inlineAdaptive` — pinning the guard.
+    let adSize = adSizeFor(cgSize: CGSize(width: .greatestFiniteMagnitude, height: 250))
+    XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: adSize), .standard)
+  }
+
+}

--- a/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoBannerFactory.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/Fakes/FakeMolocoBannerFactory.swift
@@ -20,14 +20,7 @@ import UIKit
 /// A fake implementation of MolocoBannerFactory that creates a FakeBannerRewarded.
 final class FakeMolocoBannerFactory {
 
-  enum BannerApiUsed {
-    case regularBanner
-    case MREC
-  }
-
   var fakeMolocoBanner: FakeMolocoBanner?
-
-  var bannerApiUsed: BannerApiUsed?
 
   /// Var to capture the ad unit ID that was used to create the Moloco banner ad object.
   /// Used for assertion. It is initlialized to a value that is never asserted for.
@@ -57,21 +50,12 @@ final class FakeMolocoBannerFactory {
 
 extension FakeMolocoBannerFactory: MolocoBannerFactory {
 
-  func createBanner(for adUnit: String, delegate: MolocoBannerDelegate, watermarkData: Data?) -> (
-    UIView & MolocoAd
-  )? {
-    bannerApiUsed = BannerApiUsed.regularBanner
-    adUnitIDUsedToCreateMolocoAd = adUnit
-    fakeMolocoBanner = FakeMolocoBanner(
-      bannerDelegate: delegate, loadError: loadError, shouldFailToShow: shouldFailToShow,
-      showError: showError)
-    return fakeMolocoBanner
-  }
-
-  func createMREC(for adUnit: String, delegate: MolocoBannerDelegate, watermarkData: Data?) -> (
-    UIView & MolocoAd
-  )? {
-    bannerApiUsed = BannerApiUsed.MREC
+  @MainActor
+  @available(iOS 13.0, *)
+  func createBanner(
+    for adUnit: String, size: MolocoBannerAdSize, delegate: MolocoBannerDelegate,
+    watermarkData: Data?
+  ) -> (UIView & MolocoAd)? {
     adUnitIDUsedToCreateMolocoAd = adUnit
     fakeMolocoBanner = FakeMolocoBanner(
       bannerDelegate: delegate, loadError: loadError, shouldFailToShow: shouldFailToShow,

--- a/AdapterUnitTests/MolocoAdapterTests/MolocoBannerAdTest.swift
+++ b/AdapterUnitTests/MolocoAdapterTests/MolocoBannerAdTest.swift
@@ -13,7 +13,9 @@ final class MolocoBannerAdTest: XCTestCase {
 
   static let testWatermarkData = Data()
 
-  @MainActor func testFakeBannerFactory() throws {
+  @MainActor
+  @available(iOS 13.0, *)
+  func testFakeBannerFactory() throws {
     let molocoBannerFactory = FakeMolocoBannerFactory()
     let adConfiguration = MediationBannerAdConfiguration()
     let bannerLoader = BannerAdLoader(
@@ -22,7 +24,7 @@ final class MolocoBannerAdTest: XCTestCase {
       return nil
     }
     let banner = molocoBannerFactory.createBanner(
-      for: Self.testAdUnitID, delegate: bannerLoader,
+      for: Self.testAdUnitID, size: .standard, delegate: bannerLoader,
       watermarkData: MolocoBannerAdTest.testWatermarkData)
     let fakeMolocoBanner = try XCTUnwrap(banner as? FakeMolocoBanner)
 
@@ -46,8 +48,6 @@ final class MolocoBannerAdTest: XCTestCase {
     XCTAssertEqual(
       molocoBannerFactory.fakeMolocoBanner?.bidResponseUsedToLoadMolocoAd, Self.testBidResponse
     )
-    XCTAssertEqual(
-      molocoBannerFactory.bannerApiUsed, FakeMolocoBannerFactory.BannerApiUsed.regularBanner)
   }
 
   func testMRECLoadSuccess() {
@@ -65,7 +65,12 @@ final class MolocoBannerAdTest: XCTestCase {
     XCTAssertEqual(
       molocoBannerFactory.fakeMolocoBanner?.bidResponseUsedToLoadMolocoAd, Self.testBidResponse
     )
-    XCTAssertEqual(molocoBannerFactory.bannerApiUsed, FakeMolocoBannerFactory.BannerApiUsed.MREC)
+    // The MREC ad size resolves to the MREC banner format. (The loaded
+    // MolocoBannerAdSize itself is opaque to the test, so routing is asserted at
+    // the resolver.)
+    if #available(iOS 13.0, *) {
+      XCTAssertEqual(BannerAdLoader.resolvedBannerFormat(from: mediationAdConfig.adSize), .mrec)
+    }
   }
 
   func testBannerLoadFailure() {

--- a/adapters/Moloco/MolocoAdapter/BannerAdLoader.swift
+++ b/adapters/Moloco/MolocoAdapter/BannerAdLoader.swift
@@ -71,15 +71,108 @@ final class BannerAdLoader: NSObject {
     DispatchQueue.main.async { [weak self] in
       guard let self else { return }
 
-      if isAdSizeEqualToSize(size1: adConfiguration.adSize, size2: AdSizeMediumRectangle) {
-        self.bannerAdView = self.molocoBannerFactory.createMREC(
-          for: molocoAdUnitID, delegate: self, watermarkData: adConfiguration.watermark)
-      } else {
-        self.bannerAdView = self.molocoBannerFactory.createBanner(
-          for: molocoAdUnitID, delegate: self, watermarkData: adConfiguration.watermark)
-      }
+      let molocoSize = BannerAdLoader.molocoBannerAdSize(from: adConfiguration.adSize)
+      self.bannerAdView = self.molocoBannerFactory.createBanner(
+        for: molocoAdUnitID, size: molocoSize, delegate: self,
+        watermarkData: adConfiguration.watermark)
       self.bannerAdView?.load(bidResponse: bidResponse)
     }
+  }
+
+  /// The banner format the adapter resolves a Google `AdSize` to.
+  ///
+  /// Extracted from `molocoBannerAdSize(from:)` as a pure, testable value:
+  /// `MolocoBannerAdSize` keeps its format label internal to the Moloco SDK, so
+  /// tests assert on this instead.
+  enum ResolvedBannerFormat: Equatable {
+    case standard
+    case mrec
+    case anchoredAdaptive
+    case inlineAdaptive
+  }
+
+  /// Resolves a Google Mobile Ads `AdSize` to the banner format Moloco renders.
+  ///
+  /// 1. Non-finite / non-positive sizes → `.standard` (defensive; also avoids a
+  ///    trap in the later `Int(width)` conversion for fluid / invalid sizes).
+  /// 2. Exact fixed sizes → `.standard` / `.mrec`.
+  /// 3. Full-width fixed-height banner → `.standard`. Google Mobile Ads iOS
+  ///    normalizes a fixed banner to the container width while keeping a standard
+  ///    banner height (50 / 90); once normalized the original fixed/adaptive
+  ///    signal is not recoverable, so preserve pre-adaptive fixed behavior. This
+  ///    is checked BEFORE anchored because anchored heights overlap the fixed
+  ///    heights and, after normalization, the two are indistinguishable.
+  /// 4. Height matches an anchored adaptive size for this width → `.anchoredAdaptive`,
+  ///    matched by **height** (not `AdSizeEqualToSize`, since mediation can
+  ///    normalize the width and size flags) against the current large anchored
+  ///    variants.
+  /// 5. Fallback (inline adaptive and other custom sizes) → `.inlineAdaptive`
+  ///    (Google's inline-adaptive `height == 0` signal does not exist on iOS).
+  @available(iOS 13.0, *)
+  static func resolvedBannerFormat(from adSize: AdSize) -> ResolvedBannerFormat {
+    let size = adSize.size
+    // Reject non-finite, non-positive, and out-of-range widths (e.g. fluid /
+    // invalid sizes, whose width can be a large finite sentinel) so the later
+    // `Int(width)` conversion cannot trap.
+    guard size.width.isFinite, size.width > 0, size.width < 10_000,
+      size.height.isFinite, size.height > 0
+    else {
+      return .standard
+    }
+    if isAdSizeEqualToSize(size1: adSize, size2: AdSizeBanner) {
+      return .standard
+    }
+    if isAdSizeEqualToSize(size1: adSize, size2: AdSizeMediumRectangle) {
+      return .mrec
+    }
+    if isNormalizedFixedHeightBanner(adSize) {
+      return .standard
+    }
+    if isAnchoredAdaptiveHeight(size.height, forWidth: size.width) {
+      return .anchoredAdaptive
+    }
+    return .inlineAdaptive
+  }
+
+  /// Maps a Google Mobile Ads `AdSize` to the matching Moloco `MolocoBannerAdSize`.
+  @available(iOS 13.0, *)
+  static func molocoBannerAdSize(from adSize: AdSize) -> MolocoBannerAdSize {
+    // `Int(width)` is evaluated only for the adaptive cases, which are reached
+    // only after `resolvedBannerFormat` has validated the width is finite.
+    switch resolvedBannerFormat(from: adSize) {
+    case .standard:
+      return .standard
+    case .mrec:
+      return .mrec
+    case .anchoredAdaptive:
+      return .anchoredAdaptive(width: Int(adSize.size.width))
+    case .inlineAdaptive:
+      return .inlineAdaptive(width: Int(adSize.size.width))
+    }
+  }
+
+  /// Whether `height` matches an anchored adaptive banner height for `width`.
+  /// Uses only the current (non-deprecated) large anchored variants; a small
+  /// tolerance absorbs any rounding applied to the delivered size.
+  @available(iOS 13.0, *)
+  private static func isAnchoredAdaptiveHeight(_ height: CGFloat, forWidth width: CGFloat) -> Bool
+  {
+    let anchoredSizes = [
+      largePortraitAnchoredAdaptiveBanner(width: width),
+      largeLandscapeAnchoredAdaptiveBanner(width: width),
+    ]
+    return anchoredSizes.contains { abs($0.size.height - height) < 0.5 }
+  }
+
+  /// Whether Google Mobile Ads normalized a fixed banner to a larger container
+  /// width while keeping a standard fixed banner height (50 / 90). Exact fixed
+  /// sizes are matched earlier, so this only fires once the width has been
+  /// stretched beyond the standard banner width.
+  @available(iOS 13.0, *)
+  private static func isNormalizedFixedHeightBanner(_ adSize: AdSize) -> Bool {
+    guard adSize.size.width > AdSizeBanner.size.width else { return false }
+    return adSize.size.height == AdSizeBanner.size.height
+      || adSize.size.height == AdSizeLeaderboard.size.height
   }
 
 }

--- a/adapters/Moloco/MolocoAdapter/MolocoBannerFactory.swift
+++ b/adapters/Moloco/MolocoAdapter/MolocoBannerFactory.swift
@@ -19,16 +19,15 @@ import UIKit
 /// Protocol for a factory of Moloco banner ads.
 public protocol MolocoBannerFactory {
 
+  /// Creates a Moloco banner ad for the given size. The size covers fixed
+  /// (standard, MREC) and adaptive (inline, anchored) banners.
   @MainActor
   @available(iOS 13.0, *)
-  func createBanner(for adUnit: String, delegate: MolocoBannerDelegate, watermarkData: Data?) -> (
-    UIView & MolocoAd
-  )?
-
-  @MainActor
-  @available(iOS 13.0, *)
-  func createMREC(for adUnit: String, delegate: MolocoBannerDelegate, watermarkData: Data?) -> (
-    UIView & MolocoAd
-  )?
+  func createBanner(
+    for adUnit: String,
+    size: MolocoBannerAdSize,
+    delegate: MolocoBannerDelegate,
+    watermarkData: Data?
+  ) -> (UIView & MolocoAd)?
 
 }

--- a/adapters/Moloco/MolocoAdapter/MolocoSdkImpl.swift
+++ b/adapters/Moloco/MolocoAdapter/MolocoSdkImpl.swift
@@ -73,34 +73,22 @@ extension MolocoSdkImpl: MolocoBannerFactory {
 
   @MainActor
   @available(iOS 13.0, *)
-  func createBanner(for adUnit: String, delegate: MolocoBannerDelegate, watermarkData: Data?) -> (
-    UIView & MolocoAd
-  )? {
+  func createBanner(
+    for adUnit: String,
+    size: MolocoBannerAdSize,
+    delegate: MolocoBannerDelegate,
+    watermarkData: Data?
+  ) -> (UIView & MolocoAd)? {
     guard let rootViewController = MolocoUtils.keyWindow()?.rootViewController else {
       return nil
     }
-    let bannerAd = Moloco.shared.createBanner(
+    let bannerAd = Moloco.shared.createMolocoBanner(
       params: MolocoCreateAdParams(
         adUnit: adUnit, mediation: MolocoConstants.mediationName, watermarkData: watermarkData),
+      size: size,
       viewController: rootViewController)
     bannerAd?.delegate = delegate
     return bannerAd
-  }
-
-  @MainActor
-  @available(iOS 13.0, *)
-  func createMREC(for adUnit: String, delegate: MolocoBannerDelegate, watermarkData: Data?) -> (
-    UIView & MolocoAd
-  )? {
-    guard let rootViewController = MolocoUtils.keyWindow()?.rootViewController else {
-      return nil
-    }
-    let mrecBannerAd = Moloco.shared.createMREC(
-      params: MolocoCreateAdParams(
-        adUnit: adUnit, mediation: MolocoConstants.mediationName, watermarkData: watermarkData),
-      viewController: rootViewController)
-    mrecBannerAd?.delegate = delegate
-    return mrecBannerAd
   }
 
 }


### PR DESCRIPTION
## Summary
Adds **adaptive banner** support to the Moloco iOS mediation adapter and bumps the `MolocoSDKiOS` dependency to **4.8.0** (the release that introduced the adaptive banner API). Mirrors the Android adapter change in googleads/googleads-mobile-android-mediation#1344.

Previously `BannerAdLoader` selected a Moloco banner by branching on a couple of fixed `AdSize` values (MREC vs standard). This PR replaces that with the unified `Moloco.shared.createMolocoBanner(params:size:viewController:)` API plus a size-mapping function, so the adapter can serve inline- and anchored-adaptive banners in addition to the fixed sizes.

## Changes
- **`BannerAdLoader.swift`** — add `molocoBannerAdSize(from:)`; `loadAd()` resolves `adConfiguration.adSize` and calls the unified factory.
- **`MolocoBannerFactory.swift`** — replace `createBanner` / `createMREC` with a single size-aware `createBanner(for:size:delegate:watermarkData:)`.
- **`MolocoSdkImpl.swift`** — implement it via `Moloco.shared.createMolocoBanner(...)`.
- **podspec** — `MolocoSDKiOS` 4.7.0 → 4.8.0.

## Size mapping (mirrors #1344, adapted for iOS)
1. exact `AdSizeBanner` → `.standard`, `AdSizeMediumRectangle` → `.mrec`
2. height matches `currentOrientationAnchoredAdaptiveBanner(width:)` → `.anchoredAdaptive(width:)`
3. fallback (inline adaptive, leaderboard, custom width) → `.inlineAdaptive(width:)`

iOS differences from Android: Google's inline `height == 0` signal doesn't apply on iOS (inline is the fallback), Moloco iOS has no tablet/leaderboard fixed size, and no `Context` threading is needed (the iOS anchored API takes only `width`).

## Note for reviewers
`currentOrientationAnchoredAdaptiveBanner(width:)` is deprecated in GMA 13.x (in favor of the `large…` variants). Moloco's SDK doesn't expose an anchored adaptive size for comparison, so the GMA API is the only way to distinguish anchored from inline here. Happy to switch to the `large…` variant, or to drop the anchored/inline split (Moloco renders them identically), per your preference.