### PR TITLE
Fix UnityAds adapter to fail signal collection on empty bidding token

### DIFF
--- a/AdapterUnitTests/UnityAdapterTests/AUTUnityAdapterTests.m
+++ b/AdapterUnitTests/UnityAdapterTests/AUTUnityAdapterTests.m
@@ -236,8 +236,41 @@
   [adapter
       collectSignalsForRequestParameters:params
                        completionHandler:^(NSString *_Nullable signals, NSError *_Nullable error) {
-                         XCTAssertNil(error);
-                         XCTAssertEqualObjects(signals, @"");
+                         XCTAssertNil(signals);
+                         XCTAssertEqual(error.code, GADMAdapterUnityErrorEmptyBiddingToken);
+                         XCTAssertEqualObjects(error.domain, GADMAdapterUnityErrorDomain);
+                         [expectation fulfill];
+                       }];
+  [self waitForExpectations:@[ expectation ]];
+}
+
+- (void)testEmptySignalCollections {
+  id unityAdsMock = OCMClassMock([UnityAds class]);
+  OCMStub(ClassMethod([unityAdsMock getTokenWith:OCMOCK_ANY completion:OCMOCK_ANY]))
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained void (^completionHandler)(NSString *_Nullable token);
+        [invocation getArgument:&completionHandler atIndex:3];
+        completionHandler(@"");
+      });
+
+  GADMediationAdapterUnity *adapter = [[GADMediationAdapterUnity alloc] init];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Empty signal collection."];
+
+  AUTKMediationCredentials *credentials = [[AUTKMediationCredentials alloc] init];
+  credentials.format = GADAdFormatBanner;
+  AUTKRTBMediationSignalsConfiguration *config =
+      [[AUTKRTBMediationSignalsConfiguration alloc] init];
+  config.credentials = @[ credentials ];
+  AUTKRTBRequestParameters *params = [[AUTKRTBRequestParameters alloc] init];
+  params.configuration = config;
+
+  [adapter
+      collectSignalsForRequestParameters:params
+                       completionHandler:^(NSString *_Nullable signals, NSError *_Nullable error) {
+                         XCTAssertNil(signals);
+                         XCTAssertEqual(error.code, GADMAdapterUnityErrorEmptyBiddingToken);
+                         XCTAssertEqualObjects(error.domain, GADMAdapterUnityErrorDomain);
                          [expectation fulfill];
                        }];
   [self waitForExpectations:@[ expectation ]];

--- a/adapters/Unity/Public/Headers/GADMediationAdapterUnity.h
+++ b/adapters/Unity/Public/Headers/GADMediationAdapterUnity.h
@@ -45,7 +45,9 @@ typedef NS_ENUM(NSInteger, GADMAdapterUnityErrorCode) {
   /// UnityAds returned an initialization error
   GADMAdapterUnityErrorAdInitializationFailure = 110,
   /// Unsupported ad format.
-  GADMAdapterUnityErrorAdUnsupportedAdFormat = 111
+  GADMAdapterUnityErrorAdUnsupportedAdFormat = 111,
+  /// UnityAds returned a null or empty bidding token.
+  GADMAdapterUnityErrorEmptyBiddingToken = 112
 };
 
 /// Represents the result of a consent check for advertising purposes.

--- a/adapters/Unity/UnityAdapter/GADMediationAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMediationAdapterUnity.m
@@ -84,8 +84,14 @@ static BOOL _isTestMode = NO;
     UnityAdsTokenConfiguration *config = [UnityAdsTokenConfiguration newWithAdFormat:format];
     [UnityAds getTokenWith:config
                 completion:^(NSString *_Nullable token) {
-                  NSString *unityToken = token ?: @"";
-                  completionHandler(unityToken, nil);
+                  if (token.length == 0) {
+                    completionHandler(
+                        nil, GADMAdapterUnityErrorWithCodeAndDescription(
+                                 GADMAdapterUnityErrorEmptyBiddingToken,
+                                 @"Unity Ads returned a null or empty bidding token."));
+                    return;
+                  }
+                  completionHandler(token, nil);
                 }];
   } else {
     completionHandler(


### PR DESCRIPTION
When Unity Ads returns a null or empty bidding token, the adapter was passing it through as a successful signal (an empty string). This effectively looked like a no fill downstream instead of a real failure.

This change routes null or empty tokens to the completion handler as a failure, with a new error code, GADMAdapterUnityErrorEmptyBiddingToken. Updated the existing nil token test and added a test for the empty token case.

Supersedes #1216 (recreated as a single commit to fix commit attribution).