### PR TITLE
Chartboost iOS adapter: reliability, privacy, and 300×600 banner fixes

### DIFF
--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostAdapterUtilsTest.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostAdapterUtilsTest.m
@@ -203,6 +203,35 @@
   XCTAssertEqual(consentResult, GADMAdapterChartboostConsentResultFalse);
 }
 
+#pragma mark - Trimmed Credential Tests
+
+- (void)testTrimmedCredentialTrimsSurroundingWhitespace {
+  NSDictionary *settings = @{[GADMAdapterChartboostConstants appSignature] : @"  signature  "};
+  NSString *value = GADMAdapterChartboostTrimmedCredential(
+      settings, [GADMAdapterChartboostConstants appSignature]);
+  XCTAssertEqualObjects(value, @"signature");
+}
+
+- (void)testTrimmedCredentialLeavesCleanValueUnchanged {
+  NSDictionary *settings = @{[GADMAdapterChartboostConstants appID] : @"app-id"};
+  NSString *value =
+      GADMAdapterChartboostTrimmedCredential(settings, [GADMAdapterChartboostConstants appID]);
+  XCTAssertEqualObjects(value, @"app-id");
+}
+
+- (void)testTrimmedCredentialMissingKeyReturnsNil {
+  NSString *value =
+      GADMAdapterChartboostTrimmedCredential(@{}, [GADMAdapterChartboostConstants appID]);
+  XCTAssertNil(value);
+}
+
+- (void)testTrimmedCredentialWhitespaceOnlyTrimsToEmpty {
+  NSDictionary *settings = @{[GADMAdapterChartboostConstants appID] : @"   "};
+  NSString *value =
+      GADMAdapterChartboostTrimmedCredential(settings, [GADMAdapterChartboostConstants appID]);
+  XCTAssertEqualObjects(value, @"");
+}
+
 #pragma mark - Banner Size Tests
 
 - (void)testBannerSizeFromAdSizeBanner {

--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostAdapterUtilsTest.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostAdapterUtilsTest.m
@@ -258,6 +258,15 @@
   XCTAssertEqual(size.height, CHBBannerSizeLeaderboard.height);
 }
 
+- (void)testBannerSizeFromAdSizeHalfPage {
+  NSError *error = nil;
+  CHBBannerSize size =
+      GADMAdapterChartboostBannerSizeFromAdSize(GADAdSizeFromCGSize(CGSizeMake(300, 600)), &error);
+  XCTAssertNil(error);
+  XCTAssertEqual(size.width, CHBBannerSizeHalfPage.width);
+  XCTAssertEqual(size.height, CHBBannerSizeHalfPage.height);
+}
+
 - (void)testBannerSizeFromAdSizeInvalid {
   NSError *error = nil;
   CHBBannerSize size = GADMAdapterChartboostBannerSizeFromAdSize(

--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostBannerAdTests.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostBannerAdTests.m
@@ -306,7 +306,10 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
   configuration.credentials = credentials;
   configuration.adSize = GADAdSizeBanner;
   configuration.topViewController = [[UIViewController alloc] init];
-  NSError *expectedError = [[NSError alloc] initWithDomain:@"test_domain" code:1 userInfo:nil];
+  NSError *expectedError =
+      [[NSError alloc] initWithDomain:[GADMAdapterChartboostConstants errorDomain]
+                                 code:GADMAdapterChartboostErrorInitializationFailure
+                             userInfo:nil];
 
   AUTKWaitAndAssertLoadBannerAdFailure(_adapter, configuration, expectedError);
 }

--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostInterstitialAdTests.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostInterstitialAdTests.m
@@ -152,7 +152,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testPresentation {
   [self mockSuccessfulAppStart];
-  OCMStub([_interstitialAdMock isCached]).andReturn(YES);
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_interstitialAdMock showFromViewController:controller])
       .andDo(^(NSInvocation *invocation) {
@@ -174,7 +173,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testDismiss {
   [self mockSuccessfulAppStart];
-  OCMStub([_interstitialAdMock isCached]).andReturn(YES);
 
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_interstitialAdMock showFromViewController:controller])
@@ -192,7 +190,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testClick {
   [self mockSuccessfulAppStart];
-  OCMStub([_interstitialAdMock isCached]).andReturn(YES);
 
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_interstitialAdMock showFromViewController:controller])
@@ -209,7 +206,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testClickWithError {
   [self mockSuccessfulAppStart];
-  OCMStub([_interstitialAdMock isCached]).andReturn(YES);
 
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_interstitialAdMock showFromViewController:controller])
@@ -227,7 +223,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testPresentationError {
   [self mockSuccessfulAppStart];
-  OCMStub([_interstitialAdMock isCached]).andReturn(YES);
   AUTKMediationInterstitialAdEventDelegate *eventDelegate =
       [self loadAdWithLocation:@"ad_location"];
   UIViewController *controller = [[UIViewController alloc] init];
@@ -241,21 +236,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
   XCTAssertNotNil(eventDelegate.didFailToPresentError);
   XCTAssertEqual(eventDelegate.didFailToPresentError.code, 301);
-
-  // Must not trigger any presentation callbacks.
-  XCTAssertEqual(eventDelegate.willPresentFullScreenViewInvokeCount, 0);
-  XCTAssertEqual(eventDelegate.reportImpressionInvokeCount, 0);
-}
-
-- (void)testNotCachedError {
-  [self mockSuccessfulAppStart];
-  AUTKMediationInterstitialAdEventDelegate *eventDelegate =
-      [self loadAdWithLocation:@"ad_location"];
-  UIViewController *controller = [[UIViewController alloc] init];
-  [_interstitialDelegate presentFromViewController:controller];
-
-  XCTAssertNotNil(eventDelegate.didFailToPresentError);
-  XCTAssertEqual(eventDelegate.didFailToPresentError.code, GADMAdapterChartboostErrorAdNotCached);
 
   // Must not trigger any presentation callbacks.
   XCTAssertEqual(eventDelegate.willPresentFullScreenViewInvokeCount, 0);

--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostInterstitialAdTests.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostInterstitialAdTests.m
@@ -255,7 +255,10 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
       [[AUTKMediationInterstitialAdConfiguration alloc] init];
   configuration.credentials = credentials;
 
-  NSError *expectedError = [[NSError alloc] initWithDomain:@"test_domain" code:1 userInfo:nil];
+  NSError *expectedError =
+      [[NSError alloc] initWithDomain:[GADMAdapterChartboostConstants errorDomain]
+                                 code:GADMAdapterChartboostErrorInitializationFailure
+                             userInfo:nil];
   AUTKWaitAndAssertLoadInterstitialAdFailure(_adapter, configuration, expectedError);
 }
 

--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostRewardedAdTests.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostRewardedAdTests.m
@@ -151,7 +151,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testAdDelegateCallbacks {
   [self mockSuccessfulAppStart];
-  OCMStub([_rewardedAdMock isCached]).andReturn(YES);
 
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_rewardedAdMock showFromViewController:controller]).andDo(^(NSInvocation *invocation) {
@@ -185,7 +184,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testClick {
   [self mockSuccessfulAppStart];
-  OCMStub([_rewardedAdMock isCached]).andReturn(YES);
 
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_rewardedAdMock showFromViewController:controller]).andDo(^(NSInvocation *invocation) {
@@ -200,7 +198,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testClickWithError {
   [self mockSuccessfulAppStart];
-  OCMStub([_rewardedAdMock isCached]).andReturn(YES);
 
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_rewardedAdMock showFromViewController:controller]).andDo(^(NSInvocation *invocation) {
@@ -216,7 +213,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
 - (void)testPresentationError {
   [self mockSuccessfulAppStart];
-  OCMStub([_rewardedAdMock isCached]).andReturn(YES);
   AUTKMediationRewardedAdEventDelegate *eventDelegate = [self loadAdWithLocation:@"ad_location"];
   UIViewController *controller = [[UIViewController alloc] init];
   OCMStub([_rewardedAdMock showFromViewController:controller]).andDo(^(NSInvocation *invocation) {
@@ -228,21 +224,6 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
 
   XCTAssertNotNil(eventDelegate.didFailToPresentError);
   XCTAssertEqual(eventDelegate.didFailToPresentError.code, 301);
-
-  // Must not trigger any presentation callbacks.
-  XCTAssertEqual(eventDelegate.willPresentFullScreenViewInvokeCount, 0);
-  XCTAssertEqual(eventDelegate.didStartVideoInvokeCount, 0);
-  XCTAssertEqual(eventDelegate.reportImpressionInvokeCount, 0);
-}
-
-- (void)testNotCachedError {
-  [self mockSuccessfulAppStart];
-  AUTKMediationRewardedAdEventDelegate *eventDelegate = [self loadAdWithLocation:@"ad_location"];
-  UIViewController *controller = [[UIViewController alloc] init];
-  [_rewardedDelegate presentFromViewController:controller];
-
-  XCTAssertNotNil(eventDelegate.didFailToPresentError);
-  XCTAssertEqual(eventDelegate.didFailToPresentError.code, GADMAdapterChartboostErrorAdNotCached);
 
   // Must not trigger any presentation callbacks.
   XCTAssertEqual(eventDelegate.willPresentFullScreenViewInvokeCount, 0);

--- a/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostRewardedAdTests.m
+++ b/AdapterUnitTests/ChartboostAdapterTests/AUTChartboostRewardedAdTests.m
@@ -244,7 +244,10 @@ typedef void (^AUTChartboostSetUpCompletionBlock)(CHBStartError *);
       [[AUTKMediationRewardedAdConfiguration alloc] init];
   configuration.credentials = credentials;
 
-  NSError *expectedError = [[NSError alloc] initWithDomain:@"test_domain" code:1 userInfo:nil];
+  NSError *expectedError =
+      [[NSError alloc] initWithDomain:[GADMAdapterChartboostConstants errorDomain]
+                                 code:GADMAdapterChartboostErrorInitializationFailure
+                             userInfo:nil];
   AUTKWaitAndAssertLoadRewardedAdFailure(_adapter, configuration, expectedError);
 }
 

--- a/adapters/Chartboost/BuildScript/Script_Validate.sh
+++ b/adapters/Chartboost/BuildScript/Script_Validate.sh
@@ -1,1 +1,5 @@
 #!/bin/bash
+
+# Fail the build if the adapter version has drifted across its sources of truth
+# (Swift constant, Adapter.xcconfig, podspec). See validate_version_consistency.sh.
+"$(dirname "$0")/validate_version_consistency.sh"

--- a/adapters/Chartboost/BuildScript/validate_version_consistency.sh
+++ b/adapters/Chartboost/BuildScript/validate_version_consistency.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Fails if the Chartboost adapter version disagrees across its sources of truth.
+#
+# The adapter version is hand-maintained in three places that must stay in sync:
+#   1. GADMAdapterChartboostConstants.swift  -> adapterVersion  (4-part "A.B.C.D",
+#      the ONLY value reported at runtime to GMA and sent to Chartboost)
+#   2. Configuration/Adapter.xcconfig        -> MARKETING_VERSION ("A.B.C") and
+#      CURRENT_PROJECT_VERSION (packed int A*10000 + B*100 + C)
+#   3. CocoaPods/...podspec.json             -> version ("A.B.C.D")
+#
+# These drifted once (the Swift migration shipped the previous release's value),
+# which is what this guard exists to catch. Run from CI on every PR and from the
+# Xcode build phase (Script_Validate.sh). Uses only grep/sed so it needs no
+# interpreter beyond bash.
+
+set -euo pipefail
+
+# Adapter root, resolved from this script's own location so it works both from a
+# CI checkout and from an Xcode build phase regardless of the working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+SWIFT_FILE="${ADAPTER_DIR}/ChartboostAdapter/GADMAdapterChartboostConstants.swift"
+XCCONFIG_FILE="${ADAPTER_DIR}/Configuration/Adapter.xcconfig"
+PODSPEC_FILE="${ADAPTER_DIR}/CocoaPods/GoogleMobileAdsMediationChartboost.podspec.json"
+
+for f in "${SWIFT_FILE}" "${XCCONFIG_FILE}" "${PODSPEC_FILE}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "error: expected file not found: ${f}" >&2
+    exit 1
+  fi
+done
+
+# Swift constant: the 4-part dotted number on the adapterVersion line.
+SWIFT_VER="$(grep 'adapterVersion' "${SWIFT_FILE}" | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)"
+
+# Podspec: the first "version" field.
+POD_VER="$(grep -m1 '"version"' "${PODSPEC_FILE}" | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)"
+
+# xcconfig: value after '=' for each key.
+MARKETING_VERSION="$(grep -E '^MARKETING_VERSION[[:space:]]*=' "${XCCONFIG_FILE}" | sed -E 's/^[^=]*=[[:space:]]*//' | tr -d '[:space:]')"
+CURRENT_PROJECT_VERSION="$(grep -E '^CURRENT_PROJECT_VERSION[[:space:]]*=' "${XCCONFIG_FILE}" | sed -E 's/^[^=]*=[[:space:]]*//' | tr -d '[:space:]')"
+
+if [[ -z "${SWIFT_VER}" || -z "${POD_VER}" || -z "${MARKETING_VERSION}" || -z "${CURRENT_PROJECT_VERSION}" ]]; then
+  echo "error: failed to extract one or more version values" >&2
+  echo "  swift adapterVersion    = '${SWIFT_VER}'" >&2
+  echo "  podspec version         = '${POD_VER}'" >&2
+  echo "  MARKETING_VERSION       = '${MARKETING_VERSION}'" >&2
+  echo "  CURRENT_PROJECT_VERSION = '${CURRENT_PROJECT_VERSION}'" >&2
+  exit 1
+fi
+
+fail() {
+  echo "error: Chartboost adapter version mismatch." >&2
+  echo "$1" >&2
+  echo "  swift adapterVersion    = ${SWIFT_VER}   (${SWIFT_FILE})" >&2
+  echo "  podspec version         = ${POD_VER}   (${PODSPEC_FILE})" >&2
+  echo "  MARKETING_VERSION       = ${MARKETING_VERSION}   (${XCCONFIG_FILE})" >&2
+  echo "  CURRENT_PROJECT_VERSION = ${CURRENT_PROJECT_VERSION}   (${XCCONFIG_FILE})" >&2
+  exit 1
+}
+
+# Rule 1: podspec version must exactly match the runtime Swift constant.
+if [[ "${POD_VER}" != "${SWIFT_VER}" ]]; then
+  fail "rule 1: podspec version must equal the Swift adapterVersion (4-part)."
+fi
+
+# Split the canonical Swift version into components A.B.C.D.
+IFS='.' read -r A B C D <<< "${SWIFT_VER}"
+if [[ -z "${A}" || -z "${B}" || -z "${C}" || -z "${D}" ]]; then
+  fail "adapterVersion '${SWIFT_VER}' is not the expected 4-part A.B.C.D form."
+fi
+
+# Rule 2: MARKETING_VERSION must equal the first three components.
+EXPECTED_MARKETING="${A}.${B}.${C}"
+if [[ "${MARKETING_VERSION}" != "${EXPECTED_MARKETING}" ]]; then
+  fail "rule 2: MARKETING_VERSION must equal ${EXPECTED_MARKETING} (first 3 components of adapterVersion)."
+fi
+
+# Rule 3: CURRENT_PROJECT_VERSION must equal the packed integer A*10000 + B*100 + C.
+EXPECTED_CPV="$(printf '%d%02d%02d' "${A}" "${B}" "${C}")"
+if [[ "${CURRENT_PROJECT_VERSION}" != "${EXPECTED_CPV}" ]]; then
+  fail "rule 3: CURRENT_PROJECT_VERSION must equal ${EXPECTED_CPV} (A*10000 + B*100 + C)."
+fi
+
+echo "Chartboost adapter version consistent: ${SWIFT_VER} (MARKETING_VERSION=${MARKETING_VERSION}, CURRENT_PROJECT_VERSION=${CURRENT_PROJECT_VERSION})"

--- a/adapters/Chartboost/CHANGELOG.md
+++ b/adapters/Chartboost/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Chartboost iOS Mediation Adapter Changelog
 
 #### Version 9.14.0.0 (In progress)
+- Added support for the 300x600 half-page banner size (`CHBBannerSizeHalfPage`).
 - Ported GADMAdapterChartboostConstants to Swift.
 - Ported GADMChartboostError to Swift.
 

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -95,7 +95,7 @@
   }
 
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
-  GADMAdapterChartboostRewardedAd *weakSelf = self;
+  __weak GADMAdapterChartboostRewardedAd *weakSelf = self;
   [Chartboost startWithAppID:appID
                 appSignature:appSignature
                   completion:^(CHBStartError *cbError) {

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -69,11 +69,10 @@
 }
 
 - (void)loadRewardedAd {
-  NSString *appID = [_adConfig.credentials.settings[[GADMAdapterChartboostConstants appID]]
-      stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-  NSString *appSignature =
-      [_adConfig.credentials.settings[[GADMAdapterChartboostConstants appSignature]]
-          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+  NSString *appID = GADMAdapterChartboostTrimmedCredential(
+      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);
+  NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
+      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appSignature]);
 
   if (!appID.length || !appSignature.length) {
     NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -68,6 +68,11 @@
   return self;
 }
 
+- (void)dealloc {
+  // Proactively release any Chartboost-side cached creative held by an abandoned or replaced ad.
+  [_rewardedAd clearCache];
+}
+
 - (void)loadRewardedAd {
   NSString *appID = GADMAdapterChartboostTrimmedCredential(
       _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -118,12 +118,8 @@
 }
 
 - (void)presentFromViewController:(nonnull UIViewController *)viewController {
-  if (!_rewardedAd.isCached) {
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorAdNotCached, @"Rewarded ad not cached.");
-    [_adEventDelegate didFailToPresentWithError:error];
-    return;
-  }
+  // -showFromViewController: reports a not-cached ad through -didShowAd:error:, which is routed
+  // to -didFailToPresentWithError:, so the deprecated -isCached guard is redundant.
   [_rewardedAd showFromViewController:viewController];
 }
 

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -74,52 +74,14 @@
 }
 
 - (void)loadRewardedAd {
-  NSString *appID = GADMAdapterChartboostTrimmedCredential(
-      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);
-  NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
-      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appSignature]);
-
-  if (!appID.length || !appSignature.length) {
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorInvalidServerParameters,
-        @"App ID and/or App Signature cannot be nil.");
-    _completionHandler(nil, error);
-    return;
-  }
-
-  if (SYSTEM_VERSION_LESS_THAN([GADMAdapterChartboostConstants minimumOSVersion])) {
-    NSString *logMessage = [NSString
-        stringWithFormat:
-            @"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
-            [GADMAdapterChartboostConstants minimumOSVersion]];
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorMinimumOSVersion, logMessage);
-    _completionHandler(nil, error);
-    return;
-  }
-
+  // The adapter starts the Chartboost SDK and validates the credentials and OS version before
+  // creating this wrapper, so build and cache the ad directly rather than starting again.
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
-  __weak GADMAdapterChartboostRewardedAd *weakSelf = self;
-  [Chartboost startWithAppID:appID
-                appSignature:appSignature
-                  completion:^(CHBStartError *cbError) {
-                    GADMAdapterChartboostRewardedAd *strongSelf = weakSelf;
-                    if (!strongSelf) {
-                      return;
-                    }
-
-                    if (cbError) {
-                      NSLog(@"Failed to initialize Chartboost SDK: %@", cbError);
-                      strongSelf->_completionHandler(nil, cbError);
-                      return;
-                    }
-
-                    CHBMediation *mediation = GADMAdapterChartboostMediation();
-                    strongSelf->_rewardedAd = [[CHBRewarded alloc] initWithLocation:adLocation
-                                                                          mediation:mediation
-                                                                           delegate:strongSelf];
-                    [strongSelf->_rewardedAd cache];
-                  }];
+  CHBMediation *mediation = GADMAdapterChartboostMediation();
+  _rewardedAd = [[CHBRewarded alloc] initWithLocation:adLocation
+                                            mediation:mediation
+                                             delegate:self];
+  [_rewardedAd cache];
 }
 
 - (void)presentFromViewController:(nonnull UIViewController *)viewController {

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -175,12 +175,13 @@
 }
 
 - (void)didClickAd:(CHBClickEvent *)event error:(CHBClickError *)error {
-  [_adEventDelegate reportClick];
   if (error) {
     NSError *clickError = [GADMChartboostError errorForClickError:error];
     NSLog(@"An error occurred when clicking the Chartboost rewarded ad: %@",
           clickError.localizedDescription);
+    return;
   }
+  [_adEventDelegate reportClick];
 }
 
 - (void)didDismissAd:(CHBDismissEvent *)event {

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostRewardedAd.m
@@ -194,4 +194,9 @@
   [adEventDelegate didDismissFullScreenView];
 }
 
+- (void)didExpireAd:(CHBExpirationEvent *)event {
+  NSLog(@"The Chartboost rewarded ad has expired (adID: %@). A new ad must be loaded.",
+        event.adID);
+}
+
 @end

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.h
@@ -51,6 +51,11 @@ NSString *_Nonnull GADMAdapterChartboostLocationFromConnector(
 NSString *_Nonnull GADMAdapterChartboostLocationFromAdConfiguration(
     GADMediationAdConfiguration *_Nonnull adConfiguration);
 
+/// Returns the credential for |key| in |settings|, trimmed of surrounding whitespace, or nil if the
+/// value is absent. Used so the init and load paths trim credentials identically.
+NSString *_Nullable GADMAdapterChartboostTrimmedCredential(
+    NSDictionary<NSString *, id> *_Nullable settings, NSString *_Nonnull key);
+
 /// Creates and returns a Chartboost mediation object.
 CHBMediation *_Nonnull GADMAdapterChartboostMediation(void);
 

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.m
@@ -198,9 +198,10 @@ GADMAdapterChartboostConsentResult GADMAdapterChartboostHasACConsent(NSInteger v
 
 CHBBannerSize GADMAdapterChartboostBannerSizeFromAdSize(
     GADAdSize gadAdSize, NSError *_Nullable __autoreleasing *_Nullable error) {
+  GADAdSize halfPageAdSize = GADAdSizeFromCGSize(CGSizeMake(300, 600));
   NSArray *potentials = @[
     NSValueFromGADAdSize(GADAdSizeBanner), NSValueFromGADAdSize(GADAdSizeMediumRectangle),
-    NSValueFromGADAdSize(GADAdSizeLeaderboard)
+    NSValueFromGADAdSize(GADAdSizeLeaderboard), NSValueFromGADAdSize(halfPageAdSize)
   ];
 
   GADAdSize closestSize = GADClosestValidSizeForAdSizes(gadAdSize, potentials);
@@ -210,6 +211,8 @@ CHBBannerSize GADMAdapterChartboostBannerSizeFromAdSize(
     return CHBBannerSizeMedium;
   } else if (GADAdSizeEqualToSize(closestSize, GADAdSizeLeaderboard)) {
     return CHBBannerSizeLeaderboard;
+  } else if (GADAdSizeEqualToSize(closestSize, halfPageAdSize)) {
+    return CHBBannerSizeHalfPage;
   }
   if (error) {
     NSString *description =

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.m
@@ -66,6 +66,12 @@ NSString *_Nonnull GADMAdapterChartboostLocationFromAdConfiguration(
       adConfiguration.credentials.settings[[GADMAdapterChartboostConstants adLocation]]);
 }
 
+NSString *_Nullable GADMAdapterChartboostTrimmedCredential(
+    NSDictionary<NSString *, id> *_Nullable settings, NSString *_Nonnull key) {
+  NSString *value = settings[key];
+  return [value stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+}
+
 NSString *_Nonnull GADMAdapterChartboostLocationFromString(NSString *_Nullable string) {
   NSString *adLocation =
       [string stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];

--- a/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMAdapterChartboostUtils.m
@@ -230,11 +230,17 @@ CHBBannerSize GADMAdapterChartboostBannerSizeFromAdSize(
 #pragma mark - Privacy Methods
 
 void GADMAdapterChartboostSetCOPPAUsingRequestConfiguration(void) {
+  // tagForChildDirectedTreatment and tagForUnderAgeOfConsent are deprecated in favor of
+  // ageRestrictedTreatment, but publishers may still set them, so they are read intentionally
+  // for backward compatibility.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSNumber *tagForChildDirectedTreatment =
       GADMobileAds.sharedInstance.requestConfiguration.tagForChildDirectedTreatment;
   NSNumber *tagForUnderAgeOfConsent =
       GADMobileAds.sharedInstance.requestConfiguration.tagForUnderAgeOfConsent;
-  GADAgeRestrictedTreatment *ageRestrictedTreatment =
+#pragma clang diagnostic pop
+  GADAgeRestrictedTreatment ageRestrictedTreatment =
       GADMobileAds.sharedInstance.requestConfiguration.ageRestrictedTreatment;
 
   if ([tagForChildDirectedTreatment isEqual:@YES] || [tagForUnderAgeOfConsent isEqual:@YES] ||

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.h
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.h
@@ -25,7 +25,9 @@ typedef NS_ENUM(NSInteger, GADMAdapterChartboostErrorCode) {
   /// Banner Size Mismatch.
   GADMAdapterChartboostErrorBannerSizeMismatch = 104,
   /// Device's OS version is lower than Chartboost SDK's minimum supported OS version.
-  GADMAdapterChartboostErrorMinimumOSVersion = 105
+  GADMAdapterChartboostErrorMinimumOSVersion = 105,
+  /// The ad configuration's top view controller is nil at show time.
+  GADMAdapterChartboostErrorNilViewController = 106
 };
 
 @interface GADMediationAdapterChartboost : NSObject <GADMediationAdapter>

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -66,8 +66,10 @@
   NSMutableDictionary *credentials = [[NSMutableDictionary alloc] init];
 
   for (GADMediationCredentials *cred in credentialsArray) {
-    NSString *appID = cred.settings[[GADMAdapterChartboostConstants appID]];
-    NSString *appSignature = cred.settings[[GADMAdapterChartboostConstants appSignature]];
+    NSString *appID =
+        GADMAdapterChartboostTrimmedCredential(cred.settings, [GADMAdapterChartboostConstants appID]);
+    NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
+        cred.settings, [GADMAdapterChartboostConstants appSignature]);
 
     if (appID.length && appSignature.length) {
       GADMAdapterChartboostMutableDictionarySetObjectForKey(credentials, appID, appSignature);

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -92,8 +92,7 @@
 
   NSString *appID = credentials.allKeys.firstObject;
   NSString *appSignature = credentials[appID];
-  NSLog(@"Initializing Chartboost SDK with the app ID: '%@' and app signature: '%@'", appID,
-        appSignature);
+  NSLog(@"Initializing Chartboost SDK with the app ID: '%@'", appID);
 
   [Chartboost startWithAppID:appID
                 appSignature:appSignature

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -151,6 +151,11 @@
       return;
     }
 
+    if (error) {
+      completionHandler(nil, error);
+      return;
+    }
+
     strongSelf->_rewardedAd = [[GADMAdapterChartboostRewardedAd alloc] initWithAdConfiguration:adConfiguration
                                                                  completionHandler:completionHandler];
     [strongSelf->_rewardedAd loadRewardedAd];
@@ -163,6 +168,11 @@
   [GADMediationAdapterChartboost startChartBoostWithCredentialsArray:@[adConfiguration.credentials] completionHandler:^(NSError * _Nullable error) {
     GADMediationAdapterChartboost *strongSelf = weakSelf;
     if(!strongSelf) {
+      return;
+    }
+
+    if (error) {
+      completionHandler(nil, error);
       return;
     }
 
@@ -182,6 +192,11 @@
   [GADMediationAdapterChartboost startChartBoostWithCredentialsArray:@[adConfiguration.credentials] completionHandler:^(NSError * _Nullable error) {
     GADMediationAdapterChartboost *strongSelf = weakSelf;
     if(!strongSelf) {
+      return;
+    }
+
+    if (error) {
+      completionHandler(nil, error);
       return;
     }
 

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboost.m
@@ -115,7 +115,7 @@
   NSArray *versionComponents = [versionString componentsSeparatedByString:@"."];
 
   GADVersionNumber version = {0};
-  if (versionComponents.count == 3) {
+  if (versionComponents.count >= 3) {
     version.majorVersion = [versionComponents[0] integerValue];
     version.minorVersion = [versionComponents[1] integerValue];
     version.patchVersion = [versionComponents[2] integerValue];

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -79,31 +79,9 @@
 }
 
 - (void)loadBannerAd {
-  NSString *appID = GADMAdapterChartboostTrimmedCredential(
-      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);
-  NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
-      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appSignature]);
-
-  if (!appID.length || !appSignature.length) {
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorInvalidServerParameters,
-        @"App ID and/or App Signature cannot be nil.");
-    _completionHandler(nil, error);
-    return;
-  }
-
-  if (SYSTEM_VERSION_LESS_THAN([GADMAdapterChartboostConstants minimumOSVersion])) {
-    NSString *logMessage = [NSString
-        stringWithFormat:
-            @"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
-            [GADMAdapterChartboostConstants minimumOSVersion]];
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorMinimumOSVersion, logMessage);
-    _completionHandler(nil, error);
-    return;
-  }
-
-  // Convert requested size to Chartboost Ad Size.
+  // The adapter starts the Chartboost SDK and validates the credentials and OS version before
+  // creating this wrapper, so validate the requested size and then build and cache the ad
+  // directly rather than starting again.
   NSError *error = nil;
   CHBBannerSize chartboostAdSize =
       GADMAdapterChartboostBannerSizeFromAdSize(_adConfig.adSize, &error);
@@ -113,28 +91,12 @@
   }
 
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
-  __weak GADMediationAdapterChartboostBannerAd *weakSelf = self;
-  [Chartboost startWithAppID:appID
-                appSignature:appSignature
-                  completion:^(CHBStartError *cbError) {
-                    GADMediationAdapterChartboostBannerAd *strongSelf = weakSelf;
-                    if (!strongSelf) {
-                      return;
-                    }
-
-                    if (cbError) {
-                      NSLog(@"Failed to initialize Chartboost SDK: %@", cbError);
-                      strongSelf->_completionHandler(nil, cbError);
-                      return;
-                    }
-
-                    CHBMediation *mediation = GADMAdapterChartboostMediation();
-                    strongSelf->_banner = [[CHBBanner alloc] initWithSize:chartboostAdSize
-                                                                 location:adLocation
-                                                                mediation:mediation
-                                                                 delegate:strongSelf];
-                    [strongSelf->_banner cache];
-                  }];
+  CHBMediation *mediation = GADMAdapterChartboostMediation();
+  _banner = [[CHBBanner alloc] initWithSize:chartboostAdSize
+                                   location:adLocation
+                                  mediation:mediation
+                                   delegate:self];
+  [_banner cache];
 }
 
 #pragma mark - GADMediationBannerAd Methods

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -159,12 +159,13 @@
 }
 
 - (void)didClickAd:(CHBClickEvent *)event error:(CHBClickError *)error {
-  [_adEventDelegate reportClick];
   if (error) {
     NSError *clickError = [GADMChartboostError errorForClickError:error];
     NSLog(@"An error occurred when clicking the Chartboost banner ad: %@",
           clickError.localizedDescription);
+    return;
   }
+  [_adEventDelegate reportClick];
 }
 
 - (void)didRecordImpression:(CHBImpressionEvent *)event {

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -144,7 +144,18 @@
     return;
   }
 
-  [_banner showFromViewController:_adConfig.topViewController];
+  UIViewController *viewController = _adConfig.topViewController;
+  if (!viewController) {
+    NSError *nilViewControllerError = GADMAdapterChartboostErrorWithCodeAndDescription(
+        GADMAdapterChartboostErrorNilViewController,
+        @"The ad configuration's top view controller is nil. Cannot show the banner ad.");
+    NSLog(@"Failed to show banner ad from Chartboost: %@",
+          nilViewControllerError.localizedDescription);
+    _completionHandler(nil, nilViewControllerError);
+    return;
+  }
+
+  [_banner showFromViewController:viewController];
   _adEventDelegate = _completionHandler(self, nil);
 }
 

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -172,4 +172,8 @@
   [_adEventDelegate reportImpression];
 }
 
+- (void)didExpireAd:(CHBExpirationEvent *)event {
+  NSLog(@"The Chartboost banner ad has expired (adID: %@). A new ad must be loaded.", event.adID);
+}
+
 @end

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -74,11 +74,10 @@
 }
 
 - (void)loadBannerAd {
-  NSString *appID = [_adConfig.credentials.settings[[GADMAdapterChartboostConstants appID]]
-      stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-  NSString *appSignature =
-      [_adConfig.credentials.settings[[GADMAdapterChartboostConstants appSignature]]
-          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+  NSString *appID = GADMAdapterChartboostTrimmedCredential(
+      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);
+  NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
+      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appSignature]);
 
   if (!appID.length || !appSignature.length) {
     NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -40,6 +40,11 @@
 
   /// Chartboost banner ad object
   CHBBanner *_banner;
+
+  /// Whether the banner has already reported a successful show. Chartboost may invoke
+  /// -didShowAd:error: a second time with an error after a banner has shown successfully;
+  /// that later error must not be reported to GMA as a presentation failure.
+  BOOL _bannerDidShow;
 }
 
 - (nonnull instancetype)initWithAdConfiguration:(GADMediationBannerAdConfiguration *)adConfiguration
@@ -160,13 +165,21 @@
 }
 
 - (void)didShowAd:(CHBShowEvent *)event error:(nullable CHBShowError *)error {
-  if (error) {
-    NSError *showError = [GADMChartboostError errorForShowError:error];
-    NSLog(@"Failed to show banner ad from Chartboost: %@", showError.localizedDescription);
-
-    [_adEventDelegate didFailToPresentWithError:showError];
+  if (!error) {
+    _bannerDidShow = YES;
     return;
   }
+
+  NSError *showError = [GADMChartboostError errorForShowError:error];
+  NSLog(@"Failed to show banner ad from Chartboost: %@", showError.localizedDescription);
+
+  // Per CHBAdDelegate, -didShowAd:error: may be called a second time for a banner if an error
+  // occurs after it has already shown successfully. In that case the impression has already been
+  // recorded, so log the error but do not report a presentation failure.
+  if (_bannerDidShow) {
+    return;
+  }
+  [_adEventDelegate didFailToPresentWithError:showError];
 }
 
 - (void)didClickAd:(CHBClickEvent *)event error:(CHBClickError *)error {

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -104,7 +104,7 @@
   }
 
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
-  GADMediationAdapterChartboostBannerAd *weakSelf = self;
+  __weak GADMediationAdapterChartboostBannerAd *weakSelf = self;
   [Chartboost startWithAppID:appID
                 appSignature:appSignature
                   completion:^(CHBStartError *cbError) {

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostBannerAd.m
@@ -73,6 +73,11 @@
   return self;
 }
 
+- (void)dealloc {
+  // Proactively release any Chartboost-side cached creative held by an abandoned or replaced ad.
+  [_banner clearCache];
+}
+
 - (void)loadBannerAd {
   NSString *appID = GADMAdapterChartboostTrimmedCredential(
       _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -159,12 +159,13 @@
 }
 
 - (void)didClickAd:(CHBClickEvent *)event error:(CHBClickError *)error {
-  [_adEventDelegate reportClick];
   if (error) {
     NSError *clickError = [GADMChartboostError errorForClickError:error];
     NSLog(@"An error occurred when clicking the Chartboost interstitial ad: %@",
           clickError.localizedDescription);
+    return;
   }
+  [_adEventDelegate reportClick];
 }
 
 - (void)didDismissAd:(CHBDismissEvent *)event {

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -95,7 +95,7 @@
   }
 
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
-  GADMediationAdapterChartboostInterstitialAd *weakSelf = self;
+  __weak GADMediationAdapterChartboostInterstitialAd *weakSelf = self;
   [Chartboost startWithAppID:appID
                 appSignature:appSignature
                   completion:^(CHBStartError *cbError) {

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -68,6 +68,11 @@
   return self;
 }
 
+- (void)dealloc {
+  // Proactively release any Chartboost-side cached creative held by an abandoned or replaced ad.
+  [_interstitial clearCache];
+}
+
 - (void)loadInterstitialAd {
   NSString *appID = GADMAdapterChartboostTrimmedCredential(
       _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -119,12 +119,8 @@
 }
 
 - (void)presentFromViewController:(nonnull UIViewController *)viewController {
-  if (!_interstitial.isCached) {
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorAdNotCached, @"Interstitial ad not cached.");
-    [_adEventDelegate didFailToPresentWithError:error];
-    return;
-  }
+  // -showFromViewController: reports a not-cached ad through -didShowAd:error:, which is routed
+  // to -didFailToPresentWithError:, so the deprecated -isCached guard is redundant.
   [_interstitial showFromViewController:viewController];
 }
 

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -182,4 +182,9 @@
   [_adEventDelegate reportImpression];
 }
 
+- (void)didExpireAd:(CHBExpirationEvent *)event {
+  NSLog(@"The Chartboost interstitial ad has expired (adID: %@). A new ad must be loaded.",
+        event.adID);
+}
+
 @end

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -69,11 +69,10 @@
 }
 
 - (void)loadInterstitialAd {
-  NSString *appID = [_adConfig.credentials.settings[[GADMAdapterChartboostConstants appID]]
-      stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-  NSString *appSignature =
-      [_adConfig.credentials.settings[[GADMAdapterChartboostConstants appSignature]]
-          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+  NSString *appID = GADMAdapterChartboostTrimmedCredential(
+      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);
+  NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
+      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appSignature]);
 
   if (!appID.length || !appSignature.length) {
     NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(

--- a/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
+++ b/adapters/Chartboost/ChartboostAdapter/GADMediationAdapterChartboostInterstitialAd.m
@@ -74,53 +74,14 @@
 }
 
 - (void)loadInterstitialAd {
-  NSString *appID = GADMAdapterChartboostTrimmedCredential(
-      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appID]);
-  NSString *appSignature = GADMAdapterChartboostTrimmedCredential(
-      _adConfig.credentials.settings, [GADMAdapterChartboostConstants appSignature]);
-
-  if (!appID.length || !appSignature.length) {
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorInvalidServerParameters,
-        @"App ID and/or App Signature cannot be nil.");
-    _completionHandler(nil, error);
-    return;
-  }
-
-  if (SYSTEM_VERSION_LESS_THAN([GADMAdapterChartboostConstants minimumOSVersion])) {
-    NSString *logMessage = [NSString
-        stringWithFormat:
-            @"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.",
-            [GADMAdapterChartboostConstants minimumOSVersion]];
-    NSError *error = GADMAdapterChartboostErrorWithCodeAndDescription(
-        GADMAdapterChartboostErrorMinimumOSVersion, logMessage);
-    _completionHandler(nil, error);
-    return;
-  }
-
+  // The adapter starts the Chartboost SDK and validates the credentials and OS version before
+  // creating this wrapper, so build and cache the ad directly rather than starting again.
   NSString *adLocation = GADMAdapterChartboostLocationFromAdConfiguration(_adConfig);
-  __weak GADMediationAdapterChartboostInterstitialAd *weakSelf = self;
-  [Chartboost startWithAppID:appID
-                appSignature:appSignature
-                  completion:^(CHBStartError *cbError) {
-                    GADMediationAdapterChartboostInterstitialAd *strongSelf = weakSelf;
-                    if (!strongSelf) {
-                      return;
-                    }
-
-                    if (cbError) {
-                      NSLog(@"Failed to initialize Chartboost SDK: %@", cbError);
-                      strongSelf->_completionHandler(nil, cbError);
-                      return;
-                    }
-
-                    CHBMediation *mediation = GADMAdapterChartboostMediation();
-                    strongSelf->_interstitial =
-                        [[CHBInterstitial alloc] initWithLocation:adLocation
-                                                        mediation:mediation
-                                                         delegate:strongSelf];
-                    [strongSelf->_interstitial cache];
-                  }];
+  CHBMediation *mediation = GADMAdapterChartboostMediation();
+  _interstitial = [[CHBInterstitial alloc] initWithLocation:adLocation
+                                                  mediation:mediation
+                                                   delegate:self];
+  [_interstitial cache];
 }
 
 - (void)presentFromViewController:(nonnull UIViewController *)viewController {


### PR DESCRIPTION
## Summary
Reliability, privacy, and banner-size improvements to the Chartboost iOS adapter, plus a build-time version-consistency guard.

## Changes (oldest → newest)
- [Add version-consistency guard for Chartboost adapter](https://github.com/googleads/googleads-mobile-ios-mediation/commit/77600433ef71d107404bade416cc6e56df65aa97) — wire a build-phase script that fails if the podspec version, Swift `adapterVersion`, `MARKETING_VERSION`, and `CURRENT_PROJECT_VERSION` disagree.
- [Do not report a click to GMA when the Chartboost click failed](https://github.com/googleads/googleads-mobile-ios-mediation/commit/660251763f444110f80e2e1926c4cbb930ee0396) — only forward `reportClick` when Chartboost reports no click error.
- [Stop logging the Chartboost app signature in plaintext](https://github.com/googleads/googleads-mobile-ios-mediation/commit/6247de6eeaaa978dc8ec993d148e16167a90d008) — drop the app signature from the SDK-init log line.
- [Make weakSelf actually weak in the three Chartboost ad classes](https://github.com/googleads/googleads-mobile-ios-mediation/commit/8fdd1edc18a9cdde30d91ae5c67af386cf1e98d8) — add the missing `__weak` qualifier so the start-completion bail-out can actually fire.
- [Implement didExpireAd across the three Chartboost ad classes](https://github.com/googleads/googleads-mobile-ios-mediation/commit/519deb8e14a4918cde11e2a7bfe208a2599ff1ea) — handle `didExpireAd:` for banner, interstitial, and rewarded ads.
- [Nil-check topViewController before showing the Chartboost banner](https://github.com/googleads/googleads-mobile-ios-mediation/commit/1b639aa03f0bed11664039bcc592791a89784d71) — fail the load with a clear error instead of presenting from a nil view controller.
- [Distinguish a post-show banner error from a presentation failure](https://github.com/googleads/googleads-mobile-ios-mediation/commit/2a84140d61f32806682524bbb04d8de6e3b0bd2a) — don't report a presentation failure for an error that arrives after the banner already showed.
- [Trim credentials on the init path via a shared helper](https://github.com/googleads/googleads-mobile-ios-mediation/commit/019866a244f7e02f53486655233a91a363d20f8a) — parse/trim app ID and signature through one helper so init and load paths behave identically.
- [Parse adSDKVersion defensively with >= 3 components](https://github.com/googleads/googleads-mobile-ios-mediation/commit/d511d979442771a6a20be876bae3c55d889803e9) — tolerate version strings with three or more components.
- [Drop the deprecated isCached guard before presenting](https://github.com/googleads/googleads-mobile-ios-mediation/commit/67d38e9a98377cb396afa8235c4b9327ee00ad53) — rely on `showFromViewController:` error routing instead of the deprecated `isCached` check.
- [Release Chartboost cached creative in dealloc via clearCache](https://github.com/googleads/googleads-mobile-ios-mediation/commit/959011fbbd99dec2c5c3df36d0270fd19761f77f) — proactively free cached creative for abandoned/replaced ads in `dealloc`.
- [Start the Chartboost SDK once per ad load](https://github.com/googleads/googleads-mobile-ios-mediation/commit/02e29f2fda5311cec3fe7f01e825ec0ded6ff7cf) — start the SDK once in the adapter and build/cache ads directly, rather than re-starting per ad class.
- [Add CHBBannerSizeHalfPage support for 300x600 banners](https://github.com/googleads/googleads-mobile-ios-mediation/commit/68ad578e5ba7909b0daaf2861d8ffec85fbfc813) — map a 300×600 request to Chartboost's half-page banner (ChartboostSDK 9.14.0).
- [Fix type and deprecation warnings in COPPA helper](https://github.com/googleads/googleads-mobile-ios-mediation/commit/1941765685528bb2eb4d1eef51edb7f1213e81fa) — correct the `GADAgeRestrictedTreatment` value type and suppress intentional deprecated-API reads to clear all adapter warnings.